### PR TITLE
Allow the same endpoint number to be reused for IN and OUT endpoints separately

### DIFF
--- a/device_test.go
+++ b/device_test.go
@@ -28,7 +28,7 @@ func TestClaimAndRelease(t *testing.T) {
 		cfgNum  = 1
 		if1Num  = 1
 		alt1Num = 1
-		ep1Num  = 6
+		ep1Addr = 0x86
 		alt2Num = 0
 		if2Num  = 0
 	)
@@ -58,12 +58,12 @@ func TestClaimAndRelease(t *testing.T) {
 		t.Fatalf("%s.Interface(%d, %d): %v", cfg, if1Num, alt1Num, err)
 	}
 	defer intf.Close()
-	got, err := intf.InEndpoint(ep1Num)
+	got, err := intf.InEndpoint(ep1Addr)
 	if err != nil {
-		t.Fatalf("%s.InEndpoint(%d): got error %v, want nil", intf, ep1Num, err)
+		t.Fatalf("%s.InEndpoint(%d): got error %v, want nil", intf, ep1Addr, err)
 	}
-	if want := fakeDevices[devIdx].Configs[cfgNum].Interfaces[if1Num].AltSettings[alt1Num].Endpoints[ep1Num]; !reflect.DeepEqual(got.Desc, want) {
-		t.Errorf("%s.InEndpoint(%d): got %+v, want %+v", intf, ep1Num, got, want)
+	if want := fakeDevices[devIdx].Configs[cfgNum].Interfaces[if1Num].AltSettings[alt1Num].Endpoints[ep1Addr]; !reflect.DeepEqual(got.Desc, want) {
+		t.Errorf("%s.InEndpoint(%d): got %+v, want %+v", intf, ep1Addr, got, want)
 	}
 
 	if _, err := cfg.Interface(1, 0); err == nil {

--- a/endpoint.go
+++ b/endpoint.go
@@ -21,9 +21,19 @@ import (
 	"time"
 )
 
+// EndpointAddress is a unique identifier for the endpoint, combining the endpoint number and direction.
+type EndpointAddress uint8
+
+// String implements the Stringer interface.
+func (a EndpointAddress) String() string {
+	return fmt.Sprintf("0x%02x", uint8(a))
+}
+
 // EndpointDesc contains the information about an interface endpoint, extracted
 // from the descriptor.
 type EndpointDesc struct {
+	// Address is the unique identifier of the endpoint within the interface.
+	Address EndpointAddress
 	// Number represents the endpoint number. Note that the endpoint number is different from the
 	// address field in the descriptor - address 0x82 means endpoint number 2,
 	// with endpoint direction IN.
@@ -46,18 +56,10 @@ type EndpointDesc struct {
 	UsageType UsageType
 }
 
-func endpointAddr(n int, d EndpointDirection) int {
-	addr := n
-	if d == EndpointDirectionIn {
-		addr |= 0x80
-	}
-	return addr
-}
-
 // String returns the human-readable description of the endpoint.
 func (e EndpointDesc) String() string {
 	ret := make([]string, 0, 3)
-	ret = append(ret, fmt.Sprintf("ep #%d %s (address 0x%02x) %s", e.Number, e.Direction, endpointAddr(e.Number, e.Direction), e.TransferType))
+	ret = append(ret, fmt.Sprintf("ep #%d %s (address %s) %s", e.Number, e.Direction, e.Address, e.TransferType))
 	switch e.TransferType {
 	case TransferTypeIsochronous:
 		ret = append(ret, fmt.Sprintf("- %s %s", e.IsoSyncType, e.UsageType))

--- a/fakelibusb_devices.go
+++ b/fakelibusb_devices.go
@@ -36,14 +36,16 @@ var fakeDevices = []*DeviceDesc{
 					Number:    0,
 					Alternate: 0,
 					Class:     ClassVendorSpec,
-					Endpoints: map[int]EndpointDesc{
-						1: {
+					Endpoints: map[EndpointAddress]EndpointDesc{
+						0x01: {
+							Address:       0x01,
 							Number:        1,
 							Direction:     EndpointDirectionOut,
 							MaxPacketSize: 512,
 							TransferType:  TransferTypeBulk,
 						},
-						2: {
+						0x82: {
+							Address:       0x82,
 							Number:        2,
 							Direction:     EndpointDirectionIn,
 							MaxPacketSize: 512,
@@ -82,15 +84,17 @@ var fakeDevices = []*DeviceDesc{
 					Number:    1,
 					Alternate: 0,
 					Class:     ClassVendorSpec,
-					Endpoints: map[int]EndpointDesc{
-						5: {
+					Endpoints: map[EndpointAddress]EndpointDesc{
+						0x05: {
+							Address:       0x05,
 							Number:        5,
 							Direction:     EndpointDirectionOut,
 							MaxPacketSize: 3 * 1024,
 							TransferType:  TransferTypeIsochronous,
 							UsageType:     IsoUsageTypeData,
 						},
-						6: {
+						0x86: {
+							Address:       0x86,
 							Number:        6,
 							Direction:     EndpointDirectionIn,
 							MaxPacketSize: 3 * 1024,
@@ -102,14 +106,16 @@ var fakeDevices = []*DeviceDesc{
 					Number:    1,
 					Alternate: 1,
 					Class:     ClassVendorSpec,
-					Endpoints: map[int]EndpointDesc{
-						5: {
+					Endpoints: map[EndpointAddress]EndpointDesc{
+						0x05: {
+							Address:       0x05,
 							Number:        5,
 							Direction:     EndpointDirectionOut,
 							MaxPacketSize: 2 * 1024,
 							TransferType:  TransferTypeIsochronous,
 						},
-						6: {
+						0x86: {
+							Address:       0x86,
 							Number:        6,
 							Direction:     EndpointDirectionIn,
 							MaxPacketSize: 2 * 1024,
@@ -120,18 +126,60 @@ var fakeDevices = []*DeviceDesc{
 					Number:    1,
 					Alternate: 2,
 					Class:     ClassVendorSpec,
-					Endpoints: map[int]EndpointDesc{
-						5: {
+					Endpoints: map[EndpointAddress]EndpointDesc{
+						0x05: {
+							Address:       0x05,
 							Number:        5,
 							Direction:     EndpointDirectionIn,
 							MaxPacketSize: 1024,
 							TransferType:  TransferTypeIsochronous,
 						},
-						6: {
+						0x86: {
+							Address:       0x86,
 							Number:        6,
 							Direction:     EndpointDirectionIn,
 							MaxPacketSize: 1024,
 							TransferType:  TransferTypeIsochronous,
+						},
+					},
+				}},
+			}},
+		}},
+	},
+	// Bus 001 Device 003: ID 9999:0002
+	// One config, one interface, one setup,
+	// two endpoints: 0x01 OUT, 0x81 IN.
+	&DeviceDesc{
+		Bus:      1,
+		Address:  3,
+		Spec:     Version(2, 0),
+		Device:   Version(1, 0),
+		Vendor:   ID(0x1111),
+		Product:  ID(0x1111),
+		Protocol: 255,
+		Configs: map[int]ConfigDesc{1: {
+			Number:   1,
+			MaxPower: Milliamperes(100),
+			Interfaces: []InterfaceDesc{{
+				Number: 0,
+				AltSettings: []InterfaceSetting{{
+					Number:    0,
+					Alternate: 0,
+					Class:     ClassVendorSpec,
+					Endpoints: map[EndpointAddress]EndpointDesc{
+						0x01: {
+							Address:       0x01,
+							Number:        1,
+							Direction:     EndpointDirectionOut,
+							MaxPacketSize: 512,
+							TransferType:  TransferTypeBulk,
+						},
+						0x81: {
+							Address:       0x81,
+							Number:        1,
+							Direction:     EndpointDirectionIn,
+							MaxPacketSize: 512,
+							TransferType:  TransferTypeBulk,
 						},
 					},
 				}},

--- a/usb.go
+++ b/usb.go
@@ -64,8 +64,12 @@ Config.Interface(num, altNum). The Interface struct is the representation
 of the claimed interface with a particular alternate setting.
 The descriptor of the interface is available through Interface.Setting.
 
-An interface with a particular alternate setting defines up to 15
-endpoints. An endpoint can be considered similar to a UDP/IP port,
+An interface with a particular alternate setting defines up to 30 data
+endpoints, each identified by a unique address. The endpoint address is a combination
+of endpoint number (1..15) and endpoint directionality (IN/OUT).
+IN endpoints have addresses 0x81..0x8f, while OUT endpoints 0x01..0x0f.
+
+An endpoint can be considered similar to a UDP/IP port,
 except the data transfers are unidirectional.
 
 Endpoints are represented by the Endpoint struct, and all defined endpoints
@@ -73,6 +77,8 @@ can be obtained through the Endpoints field of the Interface.Setting.
 
 Each endpoint descriptor (EndpointDesc) defined in the interface's endpoint
 map includes information about the type of the endpoint:
+
+- endpoint address
 
 - endpoint number
 


### PR DESCRIPTION
..., effectively allowing two endpoints with the same number - endpoint numbers are not unique, only endpoint addresses are.