### PR TITLE
Fixed libusb: warning [libusb_exit] some libusb_devices were leaked

### DIFF
--- a/usb.go
+++ b/usb.go
@@ -175,6 +175,7 @@ func (c *Context) OpenDevices(opener func(desc *DeviceDesc) bool) ([]*Device, er
 		if opener(desc) {
 			handle, err := libusb.open(dev)
 			if err != nil {
+				libusb.dereference(dev)
 				reterr = err
 				continue
 			}


### PR DESCRIPTION
libusb.dereference(dev) was missing if libusb.open() returns an error