### PR TITLE
make information like Serial Number, Product name and Manufacturer name accessible

### DIFF
--- a/device.go
+++ b/device.go
@@ -46,9 +46,9 @@ type DeviceDesc struct {
 	// Configuration information
 	Configs map[int]ConfigDesc
 
-	IdxSerial       int   // The index into the getStringDescriptor() to get the Serial Number
-	IdxProduct      int   // The index into the getStringDescriptor() to get the Product name
-	IdxManufacturer int   // The index into the getStringDescriptor() to get the Manufacturer name
+	iSerialNumber       int   // The index into the GetStringDescriptor() to get the Serial Number
+	iProduct            int   // The index into the GetStringDescriptor() to get the Product name
+	iManufacturer       int   // The index into the GetStringDescriptor() to get the Manufacturer name
 }
 
 // String returns a human-readable version of the device descriptor.
@@ -213,6 +213,27 @@ func (d *Device) GetStringDescriptor(descIndex int) (string, error) {
 		return "", fmt.Errorf("GetStringDescriptor(%d) called on %s after Close", descIndex, d)
 	}
 	return libusb.getStringDesc(d.handle, descIndex)
+}
+
+func (d *Device) GetSerialNumber() (string, error) {
+	if d.handle == nil {
+		return "", fmt.Errorf("GetSerialNumber() called on %s after Close", d)
+	}
+	return libusb.getStringDesc(d.handle, d.Desc.iSerialNumber)
+}
+
+func (d *Device) GetProduct() (string, error) {
+	if d.handle == nil {
+		return "", fmt.Errorf("GetProduct() called on %s after Close", d)
+	}
+	return libusb.getStringDesc(d.handle, d.Desc.iProduct)
+}
+
+func (d *Device) GetManufacturer() (string, error) {
+	if d.handle == nil {
+		return "", fmt.Errorf("GetManufacturer() called on %s after Close", d)
+	}
+	return libusb.getStringDesc(d.handle, d.Desc.iManufacturer)
 }
 
 // SetAutoDetach enables/disables automatic kernel driver detachment.

--- a/device.go
+++ b/device.go
@@ -45,6 +45,10 @@ type DeviceDesc struct {
 
 	// Configuration information
 	Configs map[int]ConfigDesc
+
+	IdxSerial       int   // The index into the getStringDescriptor() to get the Serial Number
+	IdxProduct      int   // The index into the getStringDescriptor() to get the Product name
+	IdxManufacturer int   // The index into the getStringDescriptor() to get the Manufacturer name
 }
 
 // String returns a human-readable version of the device descriptor.

--- a/libusb.go
+++ b/libusb.go
@@ -235,6 +235,9 @@ func (libusbImpl) getDeviceDesc(d *libusbDevice) (*DeviceDesc, error) {
 		SubClass:             Class(desc.bDeviceSubClass),
 		Protocol:             Protocol(desc.bDeviceProtocol),
 		MaxControlPacketSize: int(desc.bMaxPacketSize0),
+		IdxSerial:            int(desc.iSerialNumber),
+		IdxProduct:           int(desc.iProduct),
+		IdxManufacturer:      int(desc.iManufacturer),
 	}
 	// Enumerate configurations
 	cfgs := make(map[int]ConfigDesc)

--- a/libusb.go
+++ b/libusb.go
@@ -235,9 +235,9 @@ func (libusbImpl) getDeviceDesc(d *libusbDevice) (*DeviceDesc, error) {
 		SubClass:             Class(desc.bDeviceSubClass),
 		Protocol:             Protocol(desc.bDeviceProtocol),
 		MaxControlPacketSize: int(desc.bMaxPacketSize0),
-		IdxSerial:            int(desc.iSerialNumber),
-		IdxProduct:           int(desc.iProduct),
-		IdxManufacturer:      int(desc.iManufacturer),
+		iSerialNumber:        int(desc.iSerialNumber),
+		iProduct:             int(desc.iProduct),
+		iManufacturer:        int(desc.iManufacturer),
 	}
 	// Enumerate configurations
 	cfgs := make(map[int]ConfigDesc)


### PR DESCRIPTION
The function device.GetStringDescriptor() takes and index as argument for accessing the desired descriptor field. The index number of the same descriptor varies from device type to device type.
The index for the desired descriptor field can be obtained from libusb.

To get the descriptor information of a device, one can now use this code:
```
serialNr := dev.GetStringDescriptor(dev.Desc.IdxSerial)
product := dev.GetStringDescriptor(dev.Desc.IdxProduct)
manufacturer := dev.GetStringDescriptor(dev.Desc.IdxManufacturer)
```