### PR TITLE
Allocate libusb buffers in C

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -89,17 +89,23 @@ func (e *endpoint) transfer(buf []byte) (int, error) {
 		return 0, nil
 	}
 
-	t, err := newUSBTransfer(e.h, &e.Desc, buf, e.Timeout)
+	t, err := newUSBTransfer(e.h, &e.Desc, len(buf), e.Timeout)
 	if err != nil {
 		return 0, err
 	}
 	defer t.free()
+	if e.Desc.Direction == EndpointDirectionOut {
+		copy(t.data(), buf)
+	}
 
 	if err := t.submit(); err != nil {
 		return 0, err
 	}
 
 	n, err := t.wait()
+	if e.Desc.Direction == EndpointDirectionIn {
+		copy(buf, t.data())
+	}
 	if err != nil {
 		return n, err
 	}

--- a/endpoint_stream.go
+++ b/endpoint_stream.go
@@ -17,7 +17,7 @@ package gousb
 func (e *endpoint) newStream(size, count int, submit bool) (*stream, error) {
 	var ts []transferIntf
 	for i := 0; i < count; i++ {
-		t, err := newUSBTransfer(e.h, &e.Desc, make([]byte, size), e.Timeout)
+		t, err := newUSBTransfer(e.h, &e.Desc, size, e.Timeout)
 		if err != nil {
 			for _, t := range ts {
 				t.free()

--- a/fakelibusb_test.go
+++ b/fakelibusb_test.go
@@ -149,11 +149,11 @@ func (f *fakeLibusb) setAlt(d *libusbDevHandle, intf, alt uint8) error {
 	return nil
 }
 
-func (f *fakeLibusb) alloc(_ *libusbDevHandle, _ *EndpointDesc, _ time.Duration, _ int, buf []byte, done chan struct{}) (*libusbTransfer, error) {
+func (f *fakeLibusb) alloc(_ *libusbDevHandle, _ *EndpointDesc, _ time.Duration, _ int, bufLen int, done chan struct{}) (*libusbTransfer, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	t := newFakeTransferPointer()
-	f.ts[t] = &fakeTransfer{buf: buf, done: done}
+	f.ts[t] = &fakeTransfer{buf: make([]byte, bufLen), done: done}
 	return t, nil
 }
 func (f *fakeLibusb) cancel(t *libusbTransfer) error { return errors.New("not implemented") }
@@ -164,6 +164,7 @@ func (f *fakeLibusb) submit(t *libusbTransfer) error {
 	f.submitted <- ft
 	return nil
 }
+func (f *fakeLibusb) buffer(t *libusbTransfer) []byte { return f.ts[t].buf }
 func (f *fakeLibusb) data(t *libusbTransfer) (int, TransferStatus) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/rawread/main.go
+++ b/rawread/main.go
@@ -140,6 +140,9 @@ func main() {
 	}
 	dev := devs[0]
 
+	log.Print("Enabling autodetach")
+	dev.SetAutoDetach(true)
+
 	log.Printf("Setting configuration %d...", *config)
 	cfg, err := dev.Config(*config)
 	if err != nil {

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -57,13 +57,13 @@ func TestNewTransfer(t *testing.T) {
 			Direction:     tc.dir,
 			TransferType:  tc.tt,
 			MaxPacketSize: tc.maxPkt,
-		}, make([]byte, tc.buf), tc.timeout)
+		}, tc.buf, tc.timeout)
 
 		if err != nil {
 			t.Fatalf("newUSBTransfer(): %v", err)
 		}
 		defer xfer.free()
-		if got, want := len(xfer.buf), tc.wantLength; got != want {
+		if got, want := len(xfer.data()), tc.wantLength; got != want {
 			t.Errorf("xfer.buf: got %d bytes, want %d", got, want)
 		}
 	}
@@ -81,7 +81,7 @@ func TestTransferProtocol(t *testing.T) {
 			Direction:     EndpointDirectionIn,
 			TransferType:  TransferTypeBulk,
 			MaxPacketSize: 512,
-		}, make([]byte, 10240), time.Second)
+		}, 10240, time.Second)
 		if err != nil {
 			t.Fatalf("newUSBTransfer: %v", err)
 		}


### PR DESCRIPTION
Go forbids storing Go pointers in C memory. Since libusb_transfer struct is allocated by C, the underlying buffers must also be allocated in C.

@codido FYI. This fixes issue #10.