### PR TITLE
Config and interface description

### DIFF
--- a/device_test.go
+++ b/device_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestClaimAndRelease(t *testing.T) {
+	// Can't be parallelized, newFakeLibusb modifies a shared global state.
 	_, done := newFakeLibusb()
 	defer done()
 
@@ -176,6 +177,7 @@ func TestClaimAndRelease(t *testing.T) {
 }
 
 func TestInterfaceDescriptionError(t *testing.T) {
+	// Can't be parallelized, newFakeLibusb modifies a shared global state.
 	_, done := newFakeLibusb()
 	defer done()
 
@@ -188,6 +190,7 @@ func TestInterfaceDescriptionError(t *testing.T) {
 		{"no alt setting", 1, 1, 5},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			// Can't be parallelized, depends on the shared global state set before the loop.
 			c := NewContext()
 			defer c.Close()
 			dev, err := c.OpenDeviceWithVIDPID(0x8888, 0x0002)
@@ -217,6 +220,7 @@ func (*failDetachLib) detachKernelDriver(h *libusbDevHandle, i uint8) error {
 }
 
 func TestAutoDetachFailure(t *testing.T) {
+	// Can't be parallelized, newFakeLibusb modifies a shared global state.
 	fake, done := newFakeLibusb()
 	defer done()
 	libusb = &failDetachLib{fake}

--- a/device_test.go
+++ b/device_test.go
@@ -44,26 +44,45 @@ func TestClaimAndRelease(t *testing.T) {
 		t.Fatalf("OpenDeviceWithVIDPID(0x8888, 0x0002): %v", err)
 	}
 
-	mfg, err := dev.Manufacturer()
-	if err != nil {
-		t.Errorf("%s.Manufacturer(): %v", dev, err)
+	if mfg, err := dev.Manufacturer(); err != nil {
+		t.Errorf("%s.Manufacturer(): error %v", dev, err)
+	} else if want := "ACME Industries"; mfg != want {
+		t.Errorf("%s.Manufacturer(): %q, want %q", dev, mfg, want)
 	}
-	if mfg != "ACME Industries" {
-		t.Errorf("%s.Manufacturer(): %q", dev, mfg)
+	if prod, err := dev.Product(); err != nil {
+		t.Errorf("%s.Product(): error %v", dev, err)
+	} else if want := "Fidgety Gadget"; prod != want {
+		t.Errorf("%s.Product(): %q, want %q", dev, prod, want)
 	}
-	prod, err := dev.Product()
-	if err != nil {
-		t.Errorf("%s.Product(): %v", dev, err)
+	if sn, err := dev.SerialNumber(); err != nil {
+		t.Errorf("%s.SerialNumber(): error %v", dev, err)
+	} else if want := "01234567"; sn != want {
+		t.Errorf("%s.SerialNumber(): %q, want %q", dev, sn, want)
 	}
-	if prod != "Fidgety Gadget" {
-		t.Errorf("%s.Product(): %q", dev, prod)
+
+	if got, err := dev.ConfigDescription(1); err != nil {
+		t.Errorf("%s.ConfigDescription(1): %v", dev, err)
+	} else if want := "Weird configuration"; got != want {
+		t.Errorf("%s.ConfigDescription(1): %q, want %q", dev, got, want)
 	}
-	sn, err := dev.SerialNumber()
-	if err != nil {
-		t.Errorf("%s.SerialNumber(): %v", dev, err)
+	if got, err := dev.ConfigDescription(2); err == nil {
+		t.Errorf("%s.ConfigDescription(2): %q, want error", dev, got)
 	}
-	if sn != "01234567" {
-		t.Errorf("%s.SerialNumber(): %q", dev, sn)
+
+	for _, tc := range []struct {
+		intf, alt int
+		want      string
+	}{
+		{0, 0, "Boring setting"},
+		{1, 0, "Fast streaming"},
+		{1, 1, "Slower streaming"},
+		{1, 2, ""},
+	} {
+		if got, err := dev.InterfaceDescription(1, tc.intf, tc.alt); err != nil {
+			t.Errorf("%s.InterfaceDescription(1, %d, %d): %v", dev, tc.intf, tc.alt, err)
+		} else if got != tc.want {
+			t.Errorf("%s.InterfaceDescription(1, %d, %d): %q, want %q", dev, tc.intf, tc.alt, got, tc.want)
+		}
 	}
 
 	if err = dev.SetAutoDetach(true); err != nil {
@@ -153,6 +172,36 @@ func TestClaimAndRelease(t *testing.T) {
 
 	if err := dev.SetAutoDetach(false); err == nil {
 		t.Fatalf("%s.SetAutoDetach(false): got error nil, want no nil because it is closed", dev)
+	}
+}
+
+func TestInterfaceDescriptionError(t *testing.T) {
+	_, done := newFakeLibusb()
+	defer done()
+
+	for _, tc := range []struct {
+		name           string
+		cfg, intf, alt int
+	}{
+		{"no config", 2, 1, 1},
+		{"no interface", 1, 3, 1},
+		{"no alt setting", 1, 1, 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewContext()
+			defer c.Close()
+			dev, err := c.OpenDeviceWithVIDPID(0x8888, 0x0002)
+			if dev == nil {
+				t.Fatal("OpenDeviceWithVIDPID(0x8888, 0x0002): got nil device, need non-nil")
+			}
+			defer dev.Close()
+			if err != nil {
+				t.Fatalf("OpenDeviceWithVIDPID(0x8888, 0x0002): %v", err)
+			}
+			if desc, err := dev.InterfaceDescription(tc.cfg, tc.intf, tc.alt); err == nil {
+				t.Errorf("%s.InterfaceDescriptor(%d, %d, %d): %q, want error", dev, tc.cfg, tc.intf, tc.alt, desc)
+			}
+		})
 	}
 }
 

--- a/endpoint_stream_test.go
+++ b/endpoint_stream_test.go
@@ -17,6 +17,7 @@ package gousb
 import "testing"
 
 func TestEndpointReadStream(t *testing.T) {
+	// Can't be parallelized, newFakeLibusb modifies a shared global state.
 	lib, done := newFakeLibusb()
 	defer done()
 

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestEndpoint(t *testing.T) {
+	// Can't be parallelized, newFakeLibusb modifies a shared global state.
 	lib, done := newFakeLibusb()
 	defer done()
 
@@ -116,6 +117,7 @@ func TestEndpoint(t *testing.T) {
 }
 
 func TestEndpointInfo(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		ep   EndpointDesc
 		want string
@@ -161,8 +163,7 @@ func TestEndpointInfo(t *testing.T) {
 }
 
 func TestEndpointInOut(t *testing.T) {
-	defer func(i libusbIntf) { libusb = i }(libusb)
-
+	// Can't be parallelized, newFakeLibusb modifies a shared global state.
 	lib, done := newFakeLibusb()
 	defer done()
 
@@ -242,8 +243,7 @@ func TestEndpointInOut(t *testing.T) {
 }
 
 func TestSameEndpointNumberInOut(t *testing.T) {
-	defer func(i libusbIntf) { libusb = i }(libusb)
-
+	// Can't be parallelized, newFakeLibusb modifies a shared global state.
 	_, done := newFakeLibusb()
 	defer done()
 

--- a/fakelibusb_devices.go
+++ b/fakelibusb_devices.go
@@ -78,14 +78,16 @@ var fakeDevices = []fakeDevice{
 			Product:  ID(0x0002),
 			Protocol: 255,
 			Configs: map[int]ConfigDesc{1: {
-				Number:   1,
-				MaxPower: Milliamperes(100),
+				Number:         1,
+				MaxPower:       Milliamperes(100),
+				iConfiguration: 5,
 				Interfaces: []InterfaceDesc{{
 					Number: 0,
 					AltSettings: []InterfaceSetting{{
-						Number:    0,
-						Alternate: 0,
-						Class:     ClassVendorSpec,
+						Number:     0,
+						Alternate:  0,
+						Class:      ClassVendorSpec,
+						iInterface: 6,
 					}},
 				}, {
 					Number: 1,
@@ -111,6 +113,7 @@ var fakeDevices = []fakeDevice{
 								UsageType:     IsoUsageTypeData,
 							},
 						},
+						iInterface: 7,
 					}, {
 						Number:    1,
 						Alternate: 1,
@@ -131,6 +134,7 @@ var fakeDevices = []fakeDevice{
 								TransferType:  TransferTypeIsochronous,
 							},
 						},
+						iInterface: 8,
 					}, {
 						Number:    1,
 						Alternate: 2,
@@ -162,6 +166,10 @@ var fakeDevices = []fakeDevice{
 			1: "ACME Industries",
 			2: "Fidgety Gadget",
 			3: "01234567",
+			5: "Weird configuration",
+			6: "Boring setting",
+			7: "Fast streaming",
+			8: "Slower streaming",
 		},
 	},
 	// Bus 001 Device 003: ID 9999:0002

--- a/interface.go
+++ b/interface.go
@@ -52,6 +52,8 @@ type InterfaceSetting struct {
 	// Endpoints enumerates the endpoints available on this interface with
 	// this alternate setting.
 	Endpoints map[EndpointAddress]EndpointDesc
+
+	iInterface int // index of a string descriptor describing this interface.
 }
 
 func (a InterfaceSetting) sortedEndpointIds() []string {

--- a/libusb.go
+++ b/libusb.go
@@ -250,10 +250,11 @@ func (libusbImpl) getDeviceDesc(d *libusbDevice) (*DeviceDesc, error) {
 			return nil, err
 		}
 		c := ConfigDesc{
-			Number:       int(cfg.bConfigurationValue),
-			SelfPowered:  (cfg.bmAttributes & selfPoweredMask) != 0,
-			RemoteWakeup: (cfg.bmAttributes & remoteWakeupMask) != 0,
-			MaxPower:     2 * Milliamperes(cfg.MaxPower),
+			Number:         int(cfg.bConfigurationValue),
+			SelfPowered:    (cfg.bmAttributes & selfPoweredMask) != 0,
+			RemoteWakeup:   (cfg.bmAttributes & remoteWakeupMask) != 0,
+			MaxPower:       2 * Milliamperes(cfg.MaxPower),
+			iConfiguration: int(cfg.iConfiguration),
 		}
 		// at GenX speeds MaxPower is expressed in units of 8mA, not 2mA.
 		if dev.Speed == SpeedSuper {
@@ -281,11 +282,12 @@ func (libusbImpl) getDeviceDesc(d *libusbDevice) (*DeviceDesc, error) {
 			descs := make([]InterfaceSetting, 0, len(alts))
 			for altNum, alt := range alts {
 				i := InterfaceSetting{
-					Number:    int(alt.bInterfaceNumber),
-					Alternate: int(alt.bAlternateSetting),
-					Class:     Class(alt.bInterfaceClass),
-					SubClass:  Class(alt.bInterfaceSubClass),
-					Protocol:  Protocol(alt.bInterfaceProtocol),
+					Number:     int(alt.bInterfaceNumber),
+					Alternate:  int(alt.bAlternateSetting),
+					Class:      Class(alt.bInterfaceClass),
+					SubClass:   Class(alt.bInterfaceSubClass),
+					Protocol:   Protocol(alt.bInterfaceProtocol),
+					iInterface: int(alt.iInterface),
 				}
 				if ifNum != i.Number {
 					return nil, fmt.Errorf("config %d interface at index %d has number %d, USB standard states they should be identical", c.Number, ifNum, i.Number)

--- a/misc_test.go
+++ b/misc_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestBCD(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		major, minor uint8
 		bcd          BCD

--- a/transfer_stream_test.go
+++ b/transfer_stream_test.go
@@ -212,7 +212,7 @@ func TestTransferReadStream(t *testing.T) {
 			},
 		},
 	} {
-		tcNum, tc := tcNum, tc // make a local copy
+		tcNum, tc := tcNum, tc // t.Parallel will delay the execution of the test, save the iteration values.
 		t.Run(strconv.Itoa(tcNum), func(t *testing.T) {
 			t.Parallel()
 			t.Logf("Case %d: %s", tcNum, tc.desc)

--- a/transfer_stream_test.go
+++ b/transfer_stream_test.go
@@ -212,6 +212,7 @@ func TestTransferReadStream(t *testing.T) {
 			},
 		},
 	} {
+		tcNum, tc := tcNum, tc // make a local copy
 		t.Run(strconv.Itoa(tcNum), func(t *testing.T) {
 			t.Parallel()
 			t.Logf("Case %d: %s", tcNum, tc.desc)

--- a/transfer_stream_test.go
+++ b/transfer_stream_test.go
@@ -106,6 +106,7 @@ func (r readRes) String() string {
 }
 
 func TestTransferReadStream(t *testing.T) {
+	t.Parallel()
 	for tcNum, tc := range []struct {
 		desc        string
 		closeBefore int
@@ -212,6 +213,7 @@ func TestTransferReadStream(t *testing.T) {
 		},
 	} {
 		t.Run(strconv.Itoa(tcNum), func(t *testing.T) {
+			t.Parallel()
 			t.Logf("Case %d: %s", tcNum, tc.desc)
 			ftt := make([]*fakeStreamTransfer, len(tc.transfers))
 			tt := make([]transferIntf, len(tc.transfers))

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestNewTransfer(t *testing.T) {
+	// Can't be parallelized, newFakeLibusb modifies a shared global state.
 	_, done := newFakeLibusb()
 	defer done()
 
@@ -70,6 +71,7 @@ func TestNewTransfer(t *testing.T) {
 }
 
 func TestTransferProtocol(t *testing.T) {
+	// Can't be parallelized, newFakeLibusb modifies a shared global state.
 	f, done := newFakeLibusb()
 	defer done()
 

--- a/usb_test.go
+++ b/usb_test.go
@@ -18,6 +18,7 @@ package gousb
 import "testing"
 
 func TestOPenDevices(t *testing.T) {
+	// Can't be parallelized, newFakeLibusb modifies a shared global state.
 	_, done := newFakeLibusb()
 	defer done()
 
@@ -54,6 +55,7 @@ func TestOPenDevices(t *testing.T) {
 }
 
 func TestOpenDeviceWithVIDPID(t *testing.T) {
+	// Can't be parallelized, newFakeLibusb modifies a shared global state.
 	_, done := newFakeLibusb()
 	defer done()
 


### PR DESCRIPTION
Add accessors for config and interface description strings. Support calls for empty string descriptors (indicated by index 0).

@stapelberg see if the new API calls in Device (device.go) look good to you. The straightforward approach of adding .Description() to *Config/*InterfaceSetting would not work, because then it would not be possible to check the description without setting the config and claiming the interface. Could you imagine a cleaner interface?