### PR TITLE
Parallelize tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Supported platforms include:
 - darwin
 - windows
 
-This is the release 2.0 of the package [github.com/kylelemons/gousb]. Its API is not backwards-compatible with version 1.0.
+This is the release 2.0 of the package [github.com/kylelemons/gousb](https://github.com/kylelemons/gousb).
+Its API is not backwards-compatible with version 1.0.
 As of 2017-07-13 the 2.0 API is considered stable and 1.0 is deprecated.
 
 [coverimg]: https://coveralls.io/repos/github/google/gousb/badge.svg

--- a/config.go
+++ b/config.go
@@ -120,12 +120,12 @@ func (c *Config) Interface(num, alt int) (*Interface, error) {
 	}
 
 	// Claim the interface
-	if err := libusb.claim(c.dev.handle, uint8(num)); err != nil {
+	if err := c.dev.ctx.libusb.claim(c.dev.handle, uint8(num)); err != nil {
 		return nil, fmt.Errorf("failed to claim interface %d on %s: %v", num, c, err)
 	}
 
-	if err := libusb.setAlt(c.dev.handle, uint8(num), uint8(alt)); err != nil {
-		libusb.release(c.dev.handle, uint8(num))
+	if err := c.dev.ctx.libusb.setAlt(c.dev.handle, uint8(num), uint8(alt)); err != nil {
+		c.dev.ctx.libusb.release(c.dev.handle, uint8(num))
 		return nil, fmt.Errorf("failed to set alternate config %d on interface %d of %s: %v", alt, num, c, err)
 	}
 

--- a/device_test.go
+++ b/device_test.go
@@ -191,7 +191,7 @@ func TestInterfaceDescriptionError(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			// Can't be parallelized, depends on the shared global state set before the loop.
+			t.Parallel()
 			c := newContextWithImpl(newFakeLibusb())
 			defer func() {
 				if err := c.Close(); err != nil {

--- a/device_test.go
+++ b/device_test.go
@@ -21,10 +21,7 @@ import (
 )
 
 func TestClaimAndRelease(t *testing.T) {
-	// Can't be parallelized, newFakeLibusb modifies a shared global state.
-	_, done := newFakeLibusb()
-	defer done()
-
+	t.Parallel()
 	const (
 		devIdx  = 1
 		cfgNum  = 1
@@ -34,8 +31,14 @@ func TestClaimAndRelease(t *testing.T) {
 		alt2Num = 0
 		if2Num  = 0
 	)
-	c := NewContext()
-	defer c.Close()
+
+	c := newContextWithImpl(newFakeLibusb())
+	defer func() {
+		if err := c.Close(); err != nil {
+			t.Errorf("Context.Close: %v", err)
+		}
+	}()
+
 	dev, err := c.OpenDeviceWithVIDPID(0x8888, 0x0002)
 	if dev == nil {
 		t.Fatal("OpenDeviceWithVIDPID(0x8888, 0x0002): got nil device, need non-nil")
@@ -177,10 +180,7 @@ func TestClaimAndRelease(t *testing.T) {
 }
 
 func TestInterfaceDescriptionError(t *testing.T) {
-	// Can't be parallelized, newFakeLibusb modifies a shared global state.
-	_, done := newFakeLibusb()
-	defer done()
-
+	t.Parallel()
 	for _, tc := range []struct {
 		name           string
 		cfg, intf, alt int
@@ -189,10 +189,15 @@ func TestInterfaceDescriptionError(t *testing.T) {
 		{"no interface", 1, 3, 1},
 		{"no alt setting", 1, 1, 5},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// Can't be parallelized, depends on the shared global state set before the loop.
-			c := NewContext()
-			defer c.Close()
+			c := newContextWithImpl(newFakeLibusb())
+			defer func() {
+				if err := c.Close(); err != nil {
+					t.Errorf("Context.Close(): %v", err)
+				}
+			}()
 			dev, err := c.OpenDeviceWithVIDPID(0x8888, 0x0002)
 			if dev == nil {
 				t.Fatal("OpenDeviceWithVIDPID(0x8888, 0x0002): got nil device, need non-nil")
@@ -220,12 +225,9 @@ func (*failDetachLib) detachKernelDriver(h *libusbDevHandle, i uint8) error {
 }
 
 func TestAutoDetachFailure(t *testing.T) {
-	// Can't be parallelized, newFakeLibusb modifies a shared global state.
-	fake, done := newFakeLibusb()
-	defer done()
-	libusb = &failDetachLib{fake}
-
-	c := NewContext()
+	t.Parallel()
+	fake := newFakeLibusb()
+	c := newContextWithImpl(&failDetachLib{fake})
 	defer c.Close()
 	dev, err := c.OpenDeviceWithVIDPID(0x8888, 0x0002)
 	if dev == nil {

--- a/endpoint.go
+++ b/endpoint.go
@@ -77,6 +77,8 @@ type endpoint struct {
 	Desc EndpointDesc
 
 	Timeout time.Duration
+
+	ctx *Context
 }
 
 // String returns a human-readable description of the endpoint.
@@ -89,7 +91,7 @@ func (e *endpoint) transfer(buf []byte) (int, error) {
 		return 0, nil
 	}
 
-	t, err := newUSBTransfer(e.h, &e.Desc, len(buf), e.Timeout)
+	t, err := newUSBTransfer(e.ctx, e.h, &e.Desc, len(buf), e.Timeout)
 	if err != nil {
 		return 0, err
 	}

--- a/endpoint_stream.go
+++ b/endpoint_stream.go
@@ -17,7 +17,7 @@ package gousb
 func (e *endpoint) newStream(size, count int, submit bool) (*stream, error) {
 	var ts []transferIntf
 	for i := 0; i < count; i++ {
-		t, err := newUSBTransfer(e.h, &e.Desc, size, e.Timeout)
+		t, err := newUSBTransfer(e.ctx, e.h, &e.Desc, size, e.Timeout)
 		if err != nil {
 			for _, t := range ts {
 				t.free()

--- a/interface.go
+++ b/interface.go
@@ -89,7 +89,7 @@ func (i *Interface) Close() {
 	if i.config == nil {
 		return
 	}
-	libusb.release(i.config.dev.handle, uint8(i.Setting.Number))
+	i.config.dev.ctx.libusb.release(i.config.dev.handle, uint8(i.Setting.Number))
 	i.config.mu.Lock()
 	defer i.config.mu.Unlock()
 	delete(i.config.claimed, i.Setting.Number)
@@ -106,6 +106,7 @@ func (i *Interface) openEndpoint(epAddr EndpointAddress) (*endpoint, error) {
 		InterfaceSetting: i.Setting,
 		Desc:             ep,
 		h:                i.config.dev.handle,
+		ctx:              i.config.dev.ctx,
 	}, nil
 }
 

--- a/libusb.go
+++ b/libusb.go
@@ -135,7 +135,7 @@ type libusbIntf interface {
 	init() (*libusbContext, error)
 	handleEvents(*libusbContext, <-chan struct{})
 	getDevices(*libusbContext) ([]*libusbDevice, error)
-	exit(*libusbContext)
+	exit(*libusbContext) error
 	setDebug(*libusbContext, int)
 
 	// device
@@ -213,8 +213,9 @@ func (libusbImpl) getDevices(ctx *libusbContext) ([]*libusbDevice, error) {
 	return ret, nil
 }
 
-func (libusbImpl) exit(c *libusbContext) {
+func (libusbImpl) exit(c *libusbContext) error {
 	C.libusb_exit((*C.libusb_context)(c))
+	return nil
 }
 
 func (libusbImpl) setDebug(c *libusbContext, lvl int) {
@@ -478,9 +479,6 @@ func (libusbImpl) free(t *libusbTransfer) {
 func (libusbImpl) setIsoPacketLengths(t *libusbTransfer, length uint32) {
 	C.libusb_set_iso_packet_lengths((*C.struct_libusb_transfer)(t), C.uint(length))
 }
-
-// libusb is an injection point for tests
-var libusb libusbIntf = libusbImpl{}
 
 // xferDoneMap keeps a map of done callback channels for all allocated transfers.
 var xferDoneMap = struct {


### PR DESCRIPTION
Remove the global "libusb" variable. Instead, store the libusb implementation interface in the gousb.Context and objects created from Context (endpoints, transfers).

With the local scoping of libusb implementation, the tests can now be parallelized.