### PR TITLE
Add of the usb port number into the DeviceDesc structure

### DIFF
--- a/device.go
+++ b/device.go
@@ -28,6 +28,7 @@ type DeviceDesc struct {
 	Bus     int   // The bus on which the device was detected
 	Address int   // The address of the device on the bus
 	Speed   Speed // The negotiated operating speed for the device
+	Port	int   // The usb port on which the device was detected
 
 	// Version information
 	Spec   BCD // USB Specification Release Number

--- a/fakelibusb_devices.go
+++ b/fakelibusb_devices.go
@@ -29,6 +29,7 @@ var fakeDevices = []fakeDevice{
 		devDesc: &DeviceDesc{
 			Bus:      1,
 			Address:  1,
+			Port:	  1,
 			Spec:     Version(2, 0),
 			Device:   Version(1, 0),
 			Vendor:   ID(0x9999),
@@ -72,6 +73,7 @@ var fakeDevices = []fakeDevice{
 		devDesc: &DeviceDesc{
 			Bus:      1,
 			Address:  2,
+			Port:	  2,
 			Spec:     Version(2, 0),
 			Device:   Version(1, 3),
 			Vendor:   ID(0x8888),
@@ -179,6 +181,7 @@ var fakeDevices = []fakeDevice{
 		devDesc: &DeviceDesc{
 			Bus:      1,
 			Address:  3,
+			Port:	  3,
 			Spec:     Version(2, 0),
 			Device:   Version(1, 0),
 			Vendor:   ID(0x1111),

--- a/libusb.go
+++ b/libusb.go
@@ -230,6 +230,7 @@ func (libusbImpl) getDeviceDesc(d *libusbDevice) (*DeviceDesc, error) {
 	dev := &DeviceDesc{
 		Bus:                  int(C.libusb_get_bus_number((*C.libusb_device)(d))),
 		Address:              int(C.libusb_get_device_address((*C.libusb_device)(d))),
+		Port:                 int(C.libusb_get_port_number((*C.libusb_device)(d))),
 		Speed:                Speed(C.libusb_get_device_speed((*C.libusb_device)(d))),
 		Spec:                 BCD(desc.bcdUSB),
 		Device:               BCD(desc.bcdDevice),


### PR DESCRIPTION
In some development you will need to have access of the usb port number. Libusb have a function to get this informations so this pull request allow to access to this information into the DeviceDesc structure.