### PR TITLE
Set alternate setting for the interface only if required.

### DIFF
--- a/config.go
+++ b/config.go
@@ -124,9 +124,12 @@ func (c *Config) Interface(num, alt int) (*Interface, error) {
 		return nil, fmt.Errorf("failed to claim interface %d on %s: %v", num, c, err)
 	}
 
-	if err := c.dev.ctx.libusb.setAlt(c.dev.handle, uint8(num), uint8(alt)); err != nil {
-		c.dev.ctx.libusb.release(c.dev.handle, uint8(num))
-		return nil, fmt.Errorf("failed to set alternate config %d on interface %d of %s: %v", alt, num, c, err)
+	// Select an alternate setting if needed (device has multiple alternate settings).
+	if len(c.Desc.Interfaces[num].AltSettings) > 1 {
+		if err := c.dev.ctx.libusb.setAlt(c.dev.handle, uint8(num), uint8(alt)); err != nil {
+			c.dev.ctx.libusb.release(c.dev.handle, uint8(num))
+			return nil, fmt.Errorf("failed to set alternate config %d on interface %d of %s: %v", alt, num, c, err)
+		}
 	}
 
 	c.claimed[num] = true


### PR DESCRIPTION
Spec says devices must support "set interface" if they have more than
one alternate setting.