### PR TITLE
Support libusb_set_option in additon to libusb_set_debug.

### DIFF
--- a/libusb.go
+++ b/libusb.go
@@ -31,6 +31,7 @@ int gousb_compact_iso_data(struct libusb_transfer *xfer, unsigned char *status);
 struct libusb_transfer *gousb_alloc_transfer_and_buffer(int bufLen, int numIsoPackets);
 void gousb_free_transfer_and_buffer(struct libusb_transfer *xfer);
 int submit(struct libusb_transfer *xfer);
+void gousb_set_debug(libusb_context *ctx, int lvl);
 */
 import "C"
 
@@ -219,7 +220,7 @@ func (libusbImpl) exit(c *libusbContext) error {
 }
 
 func (libusbImpl) setDebug(c *libusbContext, lvl int) {
-	C.libusb_set_debug((*C.libusb_context)(c), C.int(lvl))
+	C.gousb_set_debug((*C.libusb_context)(c), C.int(lvl))
 }
 
 func (libusbImpl) getDeviceDesc(d *libusbDevice) (*DeviceDesc, error) {

--- a/usb.c
+++ b/usb.c
@@ -17,8 +17,7 @@
 
 void gousb_set_debug(libusb_context *ctx, int lvl) {
     // TODO(sebek): remove libusb_debug entirely in 2.1 or 3.0,
-    // require libusb >= 1.0.22. Accept a Go-typed levels instead
-    // of simple int.
+    // require libusb >= 1.0.22. libusb 1.0.22 sets API version 0x01000106.
 #if LIBUSB_API_VERSION >= 0x01000106
     libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, lvl);
 #else

--- a/usb.c
+++ b/usb.c
@@ -1,0 +1,27 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Copyright 2018 the gousb Authors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <libusb.h>
+
+void gousb_set_debug(libusb_context *ctx, int lvl) {
+    // TODO(sebek): remove libusb_debug entirely in 2.1 or 3.0,
+    // require libusb >= 1.0.22. Accept a Go-typed levels instead
+    // of simple int.
+#if LIBUSB_API_VERSION >= 0x01000106
+    libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, lvl);
+#else
+    libusb_set_debug(ctx, lvl);
+#endif
+}

--- a/usb.go
+++ b/usb.go
@@ -134,6 +134,8 @@ type Context struct {
 
 // Debug changes the debug level. Level 0 means no debug, higher levels
 // will print out more debugging information.
+// TODO(sebek): in the next major release, replace int levels with
+// Go-typed constants.
 func (c *Context) Debug(level int) {
 	c.libusb.setDebug(c.ctx, level)
 }


### PR DESCRIPTION
The latter is deprecated in libusb 1.0.22 and later.
I expect we'll remove the #if in a few years.