### PR TITLE
Updated dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Installation
 
 Dependencies
 ------------
-You must first install [libusb-1.0](http://libusb.org/wiki/libusb-1.0).  This is pretty straightforward on linux and darwin.  The cgo package should be able to find it if you install it in the default manner or use your distribution's package manager.  How to tell cgo how to find one installed in a non-default place is beyond the scope of this README.
+You must first install [libusb-1.0]https://github.com/libusb/libusb/wiki).  This is pretty straightforward on linux and darwin.  The cgo package should be able to find it if you install it in the default manner or use your distribution's package manager.  How to tell cgo how to find one installed in a non-default place is beyond the scope of this README.
 
 *Note*: If you are installing this on darwin, you will probably need to run `fixlibusb_darwin.sh /usr/local/lib/libusb-1.0/libusb.h` because of an LLVM incompatibility.  It shouldn't break C programs, though I haven't tried it in anger.
 


### PR DESCRIPTION
The libusb project has moved away from libusb.org, which is now a dead link. The new location is libusb.info, and the wiki lives on the github page for the project.