### PR TITLE
Fix linux-usb.org URL's

### DIFF
--- a/usbid/load.go
+++ b/usbid/load.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// LinuxUsbDotOrg is one source of files in the format used by this package.
-	LinuxUsbDotOrg = "http://www.linux-gousb.org/usb.ids"
+	LinuxUsbDotOrg = "http://www.linux-usb.org/usb.ids"
 )
 
 var (

--- a/usbid/load_data.go
+++ b/usbid/load_data.go
@@ -26,13 +26,13 @@ var LastUpdate = time.Unix(0, 1489154954940548227)
 const usbIDListData = `#
 #	List of USB ID's
 #
-#	Maintained by Stephen J. Gowdy <linux.gousb.ids@gmail.com>
+#	Maintained by Stephen J. Gowdy <linux.usb.ids@gmail.com>
 #	If you have any new entries, please submit them via
-#		http://www.linux-gousb.org/usb-ids.html
+#		http://www.linux-usb.org/usb-ids.html
 #	or send entries as patches (diff -u old new) in the
 #	body of your email (a bot will attempt to deal with it).
 #	The latest version can be obtained from
-#		http://www.linux-gousb.org/usb.ids
+#		http://www.linux-usb.org/usb.ids
 #
 # Version: 2017.02.12
 # Date:    2017-02-12 20:34:05


### PR DESCRIPTION
These were accidentally modified when the package was renamed to gousb
in commit 5200a36.