### PR TITLE
Support malformed interface descriptors

### DIFF
--- a/device_test.go
+++ b/device_test.go
@@ -81,6 +81,7 @@ func TestClaimAndRelease(t *testing.T) {
 		{1, 0, "Fast streaming"},
 		{1, 1, "Slower streaming"},
 		{1, 2, ""},
+		{3, 2, "Interface for https://github.com/google/gousb/issues/65"},
 	} {
 		if got, err := dev.InterfaceDescription(1, tc.intf, tc.alt); err != nil {
 			t.Errorf("%s.InterfaceDescription(1, %d, %d): %v", dev, tc.intf, tc.alt, err)

--- a/fakelibusb_devices.go
+++ b/fakelibusb_devices.go
@@ -29,7 +29,7 @@ var fakeDevices = []fakeDevice{
 		devDesc: &DeviceDesc{
 			Bus:      1,
 			Address:  1,
-			Port:	  1,
+			Port:     1,
 			Spec:     Version(2, 0),
 			Device:   Version(1, 0),
 			Vendor:   ID(0x9999),
@@ -73,7 +73,7 @@ var fakeDevices = []fakeDevice{
 		devDesc: &DeviceDesc{
 			Bus:      1,
 			Address:  2,
-			Port:	  2,
+			Port:     2,
 			Spec:     Version(2, 0),
 			Device:   Version(1, 3),
 			Vendor:   ID(0x8888),
@@ -158,6 +158,18 @@ var fakeDevices = []fakeDevice{
 							},
 						},
 					}},
+				}, {
+					// Malformed descriptior, non contiguous interface
+					// number (previous interface is #1), alt settings
+					// not starting from 0.
+					// See https://github.com/google/gousb/issues/65
+					Number: 3,
+					AltSettings: []InterfaceSetting{{
+						Number:     3,
+						Alternate:  2,
+						Class:      ClassVendorSpec,
+						iInterface: 9,
+					}},
 				}},
 			}},
 			iManufacturer: 1,
@@ -172,6 +184,7 @@ var fakeDevices = []fakeDevice{
 			6: "Boring setting",
 			7: "Fast streaming",
 			8: "Slower streaming",
+			9: "Interface for https://github.com/google/gousb/issues/65",
 		},
 	},
 	// Bus 001 Device 003: ID 9999:0002
@@ -181,7 +194,7 @@ var fakeDevices = []fakeDevice{
 		devDesc: &DeviceDesc{
 			Bus:      1,
 			Address:  3,
-			Port:	  3,
+			Port:     3,
 			Spec:     Version(2, 0),
 			Device:   Version(1, 0),
 			Vendor:   ID(0x1111),

--- a/interface.go
+++ b/interface.go
@@ -23,8 +23,7 @@ import (
 // InterfaceDesc contains information about a USB interface, extracted from
 // the descriptor.
 type InterfaceDesc struct {
-	// Number is the number of this interface, a zero-based index in the array
-	// of interfaces supported by the device configuration.
+	// Number is the number of this interface.
 	Number int
 	// AltSettings is a list of alternate settings supported by the interface.
 	AltSettings []InterfaceSetting


### PR DESCRIPTION
Gracefully handle descriptors where interface or alt setting numbering is not compliant with the USB spec.

The examples linked in issue #65 show:
* a Sierra Wireless modem that has only interfaces "12" and "13" (no interfaces 0..11).
* an NXP LPC Link 2 debugger that has shuffled interface IDs: 0,4,1,2,3

So we can't make a safe assumption that the interface IDs are really 0-based indices in the interface array.