### PR TITLE
Updates for incompatibilities with Go tip

### DIFF
--- a/fakelibusb_test.go
+++ b/fakelibusb_test.go
@@ -98,7 +98,7 @@ type fakeLibusb struct {
 	claims map[*libusbDevice]map[uint8]bool
 }
 
-func (f *fakeLibusb) init() (*libusbContext, error)                       { return new(libusbContext), nil }
+func (f *fakeLibusb) init() (*libusbContext, error)                       { return newContextPointer(), nil }
 func (f *fakeLibusb) handleEvents(c *libusbContext, done <-chan struct{}) { <-done }
 func (f *fakeLibusb) getDevices(*libusbContext) ([]*libusbDevice, error) {
 	ret := make([]*libusbDevice, 0, len(fakeDevices))
@@ -128,7 +128,7 @@ func (f *fakeLibusb) getDeviceDesc(d *libusbDevice) (*DeviceDesc, error) {
 	return nil, fmt.Errorf("invalid USB device %p", d)
 }
 func (f *fakeLibusb) open(d *libusbDevice) (*libusbDevHandle, error) {
-	h := new(libusbDevHandle)
+	h := newDevHandlePointer()
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.handles[h] = d

--- a/libusb.go
+++ b/libusb.go
@@ -508,10 +508,19 @@ func libusbSetDebug(c *libusbContext, lvl int) {
 	C.gousb_set_debug((*C.libusb_context)(c), C.int(lvl))
 }
 
+// for obtaining unique CGo pointers.
 func newDevicePointer() *libusbDevice {
 	return (*libusbDevice)(unsafe.Pointer(C.malloc(1)))
 }
 
 func newFakeTransferPointer() *libusbTransfer {
 	return (*libusbTransfer)(unsafe.Pointer(C.malloc(1)))
+}
+
+func newContextPointer() *libusbContext {
+	return (*libusbContext)(unsafe.Pointer(C.malloc(1)))
+}
+
+func newDevHandlePointer() *libusbDevHandle {
+	return (*libusbDevHandle)(unsafe.Pointer(C.malloc(1)))
 }


### PR DESCRIPTION
Since go 1.15 new() on CGo structs is no longer supported:

./fakelibusb_test.go:101:87: libusbContext can't be allocated in Go; it is incomplete (or unallocatable)
./fakelibusb_test.go:131:10: libusbDevHandle can't be allocated in Go; it is incomplete (or unallocatable)

Use CGo malloc to obtain unique pointers.