### PR TITLE
Add a Go module specification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/google/gousb
+
+go 1.13


### PR DESCRIPTION
... for v1.x. This will make proxy.golang.org prefer v1.x over v2.1.0+incompatible release when handing them out to module users.