### PR TITLE
Dereference device with a defer call to prevent memory leaks

### DIFF
--- a/libusb.go
+++ b/libusb.go
@@ -209,7 +209,7 @@ func (libusbImpl) getDevices(ctx *libusbContext) ([]*libusbDevice, error) {
 	for _, d := range devs {
 		ret = append(ret, (*libusbDevice)(d))
 	}
-	// devices will be dereferenced later, during close.
+	// devices must be dereferenced by the caller to prevent memoryleaks
 	C.libusb_free_device_list(list, 0)
 	return ret, nil
 }

--- a/usb.go
+++ b/usb.go
@@ -193,18 +193,20 @@ func (c *Context) OpenDevices(opener func(desc *DeviceDesc) bool) ([]*Device, er
 			continue
 		}
 
-		if opener(desc) {
-			handle, err := c.libusb.open(dev)
-			if err != nil {
-				reterr = err
-				continue
-			}
-			o := &Device{handle: handle, ctx: c, Desc: desc}
-			ret = append(ret, o)
-			c.mu.Lock()
-			c.devices[o] = true
-			c.mu.Unlock()
+		if !opener(desc) {
+			continue
 		}
+		handle, err := c.libusb.open(dev)
+		if err != nil {
+			reterr = err
+			continue
+		}
+		o := &Device{handle: handle, ctx: c, Desc: desc}
+		ret = append(ret, o)
+		c.mu.Lock()
+		c.devices[o] = true
+		c.mu.Unlock()
+
 	}
 	return ret, reterr
 }

--- a/usb.go
+++ b/usb.go
@@ -187,8 +187,8 @@ func (c *Context) OpenDevices(opener func(desc *DeviceDesc) bool) ([]*Device, er
 	var ret []*Device
 	for _, dev := range list {
 		desc, err := c.libusb.getDeviceDesc(dev)
+		defer c.libusb.dereference(dev)
 		if err != nil {
-			c.libusb.dereference(dev)
 			reterr = err
 			continue
 		}
@@ -196,7 +196,6 @@ func (c *Context) OpenDevices(opener func(desc *DeviceDesc) bool) ([]*Device, er
 		if opener(desc) {
 			handle, err := c.libusb.open(dev)
 			if err != nil {
-				c.libusb.dereference(dev)
 				reterr = err
 				continue
 			}
@@ -205,8 +204,6 @@ func (c *Context) OpenDevices(opener func(desc *DeviceDesc) bool) ([]*Device, er
 			c.mu.Lock()
 			c.devices[o] = true
 			c.mu.Unlock()
-		} else {
-			c.libusb.dereference(dev)
 		}
 	}
 	return ret, reterr


### PR DESCRIPTION
This PR fixes the memory leak mentioned in #97 

`gousb.OpenDevices` currently only dereferences libusb device pointers when opening is unsuccessful or when the opener returns false. 
This can cause a memory leak that becomes mostly visible when using multiple libusb contexts in a long running application. 

The fix is to always call `c.libusb.dereference(dev)` so the device reference counter is decreased when OpenDevices is done. That is not a problem as libusb increases the reference counter internally on the `c.libusb.open(dev)` call and releases it when we call `c.libusb.close(dev)` again. 
