### PR TITLE
Add Path to DeviceDesc

### DIFF
--- a/device.go
+++ b/device.go
@@ -30,14 +30,15 @@ type DeviceDesc struct {
 	Address int
 	// The negotiated operating speed for the device
 	Speed Speed
-	// The pyhsical port on the parent hub on which the device is connected. Ports are numbered from 1,
-	// excepting root hub devices which are always 0
+	// The pyhsical port on the parent hub on which the device is connected.
+	// Ports are numbered from 1, excepting root hub devices which are always 0.
 	Port int
-	// The physical path of connected parent port numbers, starting at the root hub device
-	// A path length of 1 indicates that this device is connected directly to a root hub,
-	// A path length of 2 or more are connected to intermediate devices,
-	// Root hub devices have an empty path
-	// i.e. [1,2,3] represents a device connected to port 3 of a device connected to port 2 of a device attached to port 1 of a root hub.
+	// Physical path of connected parent ports, starting at the root hub device.
+	// A path length of 0 represents a root hub device,
+	// a path length of 1 represents a device directly connected to a root hub,
+	// a path length of 2 or more are connected to intermediate hub devices.
+	// e.g. [1,2,3] represents a device connected to port 3 of a hub connected
+	// to port 2 of a hub connected to port 1 of a root hub.
 	Path []int
 
 	// Version information

--- a/device.go
+++ b/device.go
@@ -22,19 +22,23 @@ import (
 	"time"
 )
 
-// DevicePath is a representation of a USB port path
-// The path describes the physical port connections, ordered from Bus to Device.
-type DevicePath []int
-
 // DeviceDesc is a representation of a USB device descriptor.
-// Root Hubs are represented solely by Bus, do not have a path, and have a port value of 0.
 type DeviceDesc struct {
-	// Bus information
-	Bus     int        // The bus on which the device was detected
-	Address int        // The address of the device on the bus
-	Speed   Speed      // The negotiated operating speed for the device
-	Port    int        // The usb port on which the device was detected
-	Path    DevicePath // The usb port path of the device
+	// The bus on which the device was detected
+	Bus int
+	// The address of the device on the bus
+	Address int
+	// The negotiated operating speed for the device
+	Speed Speed
+	// The pyhsical port on the parent hub on which the device is connected. Ports are numbered from 1,
+	// excepting root hub devices which are always 0
+	Port int
+	// The physical path of connected parent port numbers, starting at the root hub device
+	// A path length of 1 indicates that this device is connected directly to a root hub,
+	// A path length of 2 or more are connected to intermediate devices,
+	// Root hub devices have an empty path
+	// i.e. [1,2,3] represents a device connected to port 3 of a device connected to port 2 of a device attached to port 1 of a root hub.
+	Path []int
 
 	// Version information
 	Spec   BCD // USB Specification Release Number

--- a/device.go
+++ b/device.go
@@ -22,14 +22,19 @@ import (
 	"time"
 )
 
+// DevicePath is a representation of a USB port path
+// The path describes the physical port connections, ordered from Bus to Device.
+type DevicePath []int
+
 // DeviceDesc is a representation of a USB device descriptor.
+// Root Hubs are represented solely by Bus, do not have a path, and have a port value of 0.
 type DeviceDesc struct {
 	// Bus information
-	Bus     int     // The bus on which the device was detected
-	Address int     // The address of the device on the bus
-	Speed   Speed   // The negotiated operating speed for the device
-	Port    int     // The usb port on which the device was detected
-	Path    []uint8 //The usb port path of the device
+	Bus     int        // The bus on which the device was detected
+	Address int        // The address of the device on the bus
+	Speed   Speed      // The negotiated operating speed for the device
+	Port    int        // The usb port on which the device was detected
+	Path    DevicePath // The usb port path of the device
 
 	// Version information
 	Spec   BCD // USB Specification Release Number

--- a/device.go
+++ b/device.go
@@ -25,10 +25,11 @@ import (
 // DeviceDesc is a representation of a USB device descriptor.
 type DeviceDesc struct {
 	// Bus information
-	Bus     int   // The bus on which the device was detected
-	Address int   // The address of the device on the bus
-	Speed   Speed // The negotiated operating speed for the device
-	Port    int   // The usb port on which the device was detected
+	Bus     int     // The bus on which the device was detected
+	Address int     // The address of the device on the bus
+	Speed   Speed   // The negotiated operating speed for the device
+	Port    int     // The usb port on which the device was detected
+	Path    []uint8 //The usb port path of the device
 
 	// Version information
 	Spec   BCD // USB Specification Release Number

--- a/libusb.go
+++ b/libusb.go
@@ -234,10 +234,12 @@ func (libusbImpl) getDeviceDesc(d *libusbDevice) (*DeviceDesc, error) {
 	if pathLen > 0 {
 		path = data[:pathLen-1]
 	}
+	port := int(C.libusb_get_port_number((*C.libusb_device)(d)))
+	path = append(path, uint8(port))
 	dev := &DeviceDesc{
 		Bus:                  int(C.libusb_get_bus_number((*C.libusb_device)(d))),
 		Address:              int(C.libusb_get_device_address((*C.libusb_device)(d))),
-		Port:                 int(C.libusb_get_port_number((*C.libusb_device)(d))),
+		Port:                 port,
 		Path:                 path,
 		Speed:                Speed(C.libusb_get_device_speed((*C.libusb_device)(d))),
 		Spec:                 BCD(desc.bcdUSB),

--- a/libusb.go
+++ b/libusb.go
@@ -228,10 +228,17 @@ func (libusbImpl) getDeviceDesc(d *libusbDevice) (*DeviceDesc, error) {
 	if err := fromErrNo(C.libusb_get_device_descriptor((*C.libusb_device)(d), &desc)); err != nil {
 		return nil, err
 	}
+	var data [8]uint8
+	pathLen := int(C.libusb_get_port_numbers((*C.libusb_device)(d), (*C.uint8_t)(&data[0]), 8))
+	path := []uint8{}
+	if pathLen > 0 {
+		path = data[:pathLen-1]
+	}
 	dev := &DeviceDesc{
 		Bus:                  int(C.libusb_get_bus_number((*C.libusb_device)(d))),
 		Address:              int(C.libusb_get_device_address((*C.libusb_device)(d))),
 		Port:                 int(C.libusb_get_port_number((*C.libusb_device)(d))),
+		Path:                 path,
 		Speed:                Speed(C.libusb_get_device_speed((*C.libusb_device)(d))),
 		Spec:                 BCD(desc.bcdUSB),
 		Device:               BCD(desc.bcdDevice),

--- a/libusb.go
+++ b/libusb.go
@@ -224,13 +224,13 @@ func (libusbImpl) setDebug(c *libusbContext, lvl int) {
 }
 
 func (libusbImpl) getDeviceDesc(d *libusbDevice) (*DeviceDesc, error) {
-	var desc, pathData, path = C.struct_libusb_device_descriptor, [8]uint8{}, []uint8{}
+	var desc, pathData, path = C.struct_libusb_device_descriptor{}, [8]uint8{}, []uint8{}
 	if err := fromErrNo(C.libusb_get_device_descriptor((*C.libusb_device)(d), &desc)); err != nil {
 		return nil, err
 	}
-	pathLen := int(C.libusb_get_port_numbers((*C.libusb_device)(d), (*C.uint8_t)(&data[0]), 8))
+	pathLen := int(C.libusb_get_port_numbers((*C.libusb_device)(d), (*C.uint8_t)(&pathData[0]), 8))
 	if pathLen > 0 {
-		path = data[:pathLen-1]
+		path = pathData[:pathLen-1]
 	}
 	port := int(C.libusb_get_port_number((*C.libusb_device)(d)))
 	path = append(path, uint8(port))

--- a/libusb.go
+++ b/libusb.go
@@ -224,13 +224,11 @@ func (libusbImpl) setDebug(c *libusbContext, lvl int) {
 }
 
 func (libusbImpl) getDeviceDesc(d *libusbDevice) (*DeviceDesc, error) {
-	var desc C.struct_libusb_device_descriptor
+	var desc, pathData, path = C.struct_libusb_device_descriptor, [8]uint8{}, []uint8{}
 	if err := fromErrNo(C.libusb_get_device_descriptor((*C.libusb_device)(d), &desc)); err != nil {
 		return nil, err
 	}
-	var data [8]uint8
 	pathLen := int(C.libusb_get_port_numbers((*C.libusb_device)(d), (*C.uint8_t)(&data[0]), 8))
-	path := []uint8{}
 	if pathLen > 0 {
 		path = data[:pathLen-1]
 	}

--- a/libusb.go
+++ b/libusb.go
@@ -233,12 +233,12 @@ func (libusbImpl) getDeviceDesc(d *libusbDevice) (*DeviceDesc, error) {
 	if err := fromErrNo(C.libusb_get_device_descriptor((*C.libusb_device)(d), &desc)); err != nil {
 		return nil, err
 	}
-	if pathLen := int(C.libusb_get_port_numbers((*C.libusb_device)(d), (*C.uint8_t)(&pathData[0]), 8)); pathLen != 0 {
-		for _, nPort := range pathData[:pathLen] {
-			port = int(nPort)
-			path = append(path, port)
-		}
-	} // else default to port = 0, path = [] for root device
+	pathLen := int(C.libusb_get_port_numbers((*C.libusb_device)(d), (*C.uint8_t)(&pathData[0]), 8))
+	for _, nPort := range pathData[:pathLen] {
+		port = int(nPort)
+		path = append(path, port)
+	}
+	// Defaults to port = 0, path = [] for root device
 	dev := &DeviceDesc{
 		Bus:                  int(C.libusb_get_bus_number((*C.libusb_device)(d))),
 		Address:              int(C.libusb_get_device_address((*C.libusb_device)(d))),


### PR DESCRIPTION
See #28.

Implemented `Path` as part of `getDeviceDesc` as suggested.
Appended port to path to give complete device port path (except for bus number).  This gives a consistent result with its name in context and with comparable usb library in python.