### PR TITLE
Add a retract version for v2.1.0+incompatible.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
 module github.com/google/gousb
 
-go 1.13
+go 1.16
+
+// Released in error, v1.* remains the current version.
+retract v2.1.0+incompatible


### PR DESCRIPTION
This will avoid listing this version in "go list -m -versions", which
is used by GitHub's dependabot. The "go list" is expected to list
versions oldest to newest, but it doesn't exclude the "+incompatible"
versions and treats v2.1.0 as the newest. We don't want that, 1.1 is the
latest at the moment.