### PR TITLE
Add functions to achieve android support

### DIFF
--- a/fakelibusb_test.go
+++ b/fakelibusb_test.go
@@ -98,7 +98,9 @@ type fakeLibusb struct {
 	claims map[*libusbDevice]map[uint8]bool
 }
 
-func (f *fakeLibusb) init() (*libusbContext, error)                       { return newContextPointer(), nil }
+func (f *fakeLibusb) init(flags ...libusbOpt) (*libusbContext, error) {
+	return newContextPointer(), nil
+}
 func (f *fakeLibusb) handleEvents(c *libusbContext, done <-chan struct{}) { <-done }
 func (f *fakeLibusb) getDevices(*libusbContext) ([]*libusbDevice, error) {
 	ret := make([]*libusbDevice, 0, len(fakeDevices))

--- a/fakelibusb_test.go
+++ b/fakelibusb_test.go
@@ -110,7 +110,7 @@ func (f *fakeLibusb) getDevices(*libusbContext) ([]*libusbDevice, error) {
 	return ret, nil
 }
 
-func (f *fakeLibusb) wrapSysDevice(ctx *libusbContext, systemDeviceHandle int) (*libusbDevHandle, error) {
+func (f *fakeLibusb) wrapSysDevice(ctx *libusbContext, systemDeviceHandle uintptr) (*libusbDevHandle, error) {
 	//TODO should we do something for this
 	return nil, nil
 }

--- a/fakelibusb_test.go
+++ b/fakelibusb_test.go
@@ -108,6 +108,16 @@ func (f *fakeLibusb) getDevices(*libusbContext) ([]*libusbDevice, error) {
 	return ret, nil
 }
 
+func (f *fakeLibusb) wrapSysDevice(ctx *libusbContext, systemDeviceHandle int) (*libusbDevHandle, error) {
+	//TODO should we do something for this
+	return nil, nil
+}
+
+func (f *fakeLibusb) getDevice(d *libusbDevHandle) (*libusbDevice, error) {
+	//TODO should we do something for this
+	return nil, nil
+}
+
 func (f *fakeLibusb) exit(*libusbContext) error {
 	close(f.submitted)
 	if got := len(f.ts); got > 0 {

--- a/libusb.go
+++ b/libusb.go
@@ -186,12 +186,12 @@ func (libusbImpl) init(flags ...libusbOpt) (*libusbContext, error) {
 		return nil, err
 	}
 
-	// for _, flag := range flags {
-	// 	switch flag {
-	// 	case LIBUSB_OPTION_NO_DEVICE_DISCOVERY:
-	// 		C.gousb_no_svc_discovery(ctx)
-	// 	}
-	// }
+	for _, flag := range flags {
+		switch flag {
+		case LIBUSB_OPTION_NO_DEVICE_DISCOVERY:
+			C.gousb_disable_device_discovery(ctx)
+		}
+	}
 
 	return (*libusbContext)(ctx), nil
 }

--- a/libusb.go
+++ b/libusb.go
@@ -143,6 +143,7 @@ type libusbIntf interface {
 	dereference(*libusbDevice)
 	getDeviceDesc(*libusbDevice) (*DeviceDesc, error)
 	open(*libusbDevice) (*libusbDevHandle, error)
+	wrapSysDevice(*libusbContext, int) (*libusbDevHandle, error)
 
 	close(*libusbDevHandle)
 	reset(*libusbDevHandle) error
@@ -152,6 +153,7 @@ type libusbIntf interface {
 	getStringDesc(*libusbDevHandle, int) (string, error)
 	setAutoDetach(*libusbDevHandle, int) error
 	detachKernelDriver(*libusbDevHandle, uint8) error
+	getDevice(*libusbDevHandle) (*libusbDevice, error)
 
 	// interface
 	claim(*libusbDevHandle, uint8) error
@@ -215,6 +217,24 @@ func (libusbImpl) getDevices(ctx *libusbContext) ([]*libusbDevice, error) {
 	// devices must be dereferenced by the caller to prevent memory leaks.
 	C.libusb_free_device_list(list, 0)
 	return ret, nil
+}
+
+func (libusbImpl) wrapSysDevice(ctx *libusbContext, systemDeviceHandle int) (*libusbDevHandle, error) {
+	var handle *C.libusb_device_handle
+	if ret := C.libusb_wrap_sys_device((*C.libusb_context)(ctx), C.intptr_t(systemDeviceHandle), &handle); ret < 0 {
+		return nil, fromErrNo(C.int(ret))
+	}
+
+	return (*libusbDevHandle)(handle), nil
+}
+
+func (libusbImpl) getDevice(d *libusbDevHandle) (*libusbDevice, error) {
+	device := C.libusb_get_device((*C.libusb_device_handle)(d))
+	if device == nil {
+		return nil, fmt.Errorf("libusb_get_device failed")
+	}
+
+	return (*libusbDevice)(device), nil
 }
 
 func (libusbImpl) exit(c *libusbContext) error {

--- a/libusb.go
+++ b/libusb.go
@@ -150,7 +150,7 @@ type libusbIntf interface {
 	dereference(*libusbDevice)
 	getDeviceDesc(*libusbDevice) (*DeviceDesc, error)
 	open(*libusbDevice) (*libusbDevHandle, error)
-	wrapSysDevice(*libusbContext, int) (*libusbDevHandle, error)
+	wrapSysDevice(*libusbContext, uintptr) (*libusbDevHandle, error)
 
 	close(*libusbDevHandle)
 	reset(*libusbDevHandle) error
@@ -234,9 +234,9 @@ func (libusbImpl) getDevices(ctx *libusbContext) ([]*libusbDevice, error) {
 	return ret, nil
 }
 
-func (libusbImpl) wrapSysDevice(ctx *libusbContext, systemDeviceHandle int) (*libusbDevHandle, error) {
+func (libusbImpl) wrapSysDevice(ctx *libusbContext, fd uintptr) (*libusbDevHandle, error) {
 	var handle *C.libusb_device_handle
-	if ret := C.libusb_wrap_sys_device((*C.libusb_context)(ctx), C.intptr_t(systemDeviceHandle), &handle); ret < 0 {
+	if ret := C.libusb_wrap_sys_device((*C.libusb_context)(ctx), C.intptr_t(fd), &handle); ret < 0 {
 		return nil, fromErrNo(C.int(ret))
 	}
 

--- a/usb.c
+++ b/usb.c
@@ -24,3 +24,7 @@ void gousb_set_debug(libusb_context *ctx, int lvl) {
     libusb_set_debug(ctx, lvl);
 #endif
 }
+
+int gousb_disable_device_discovery(libusb_context *ctx) {
+  return libusb_set_option(ctx, 2);
+}

--- a/usb.go
+++ b/usb.go
@@ -128,7 +128,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"syscall"
 )
 
 // Context manages all resources related to USB device handling.
@@ -211,12 +210,7 @@ func (c *Context) OpenDevices(opener func(desc *DeviceDesc) bool) ([]*Device, er
 	return ret, reterr
 }
 
-func (c *Context) OpenDeviceWithFileDescriptor(fileDescriptor string) (*Device, error) {
-	fd, err := syscall.Open(fileDescriptor, syscall.O_RDWR, 0)
-	if err != nil {
-		return nil, err
-	}
-
+func (c *Context) OpenDeviceWithFileDescriptor(fd uintptr) (*Device, error) {
 	handle, err := c.libusb.wrapSysDevice(c.ctx, fd)
 	if err != nil {
 		return nil, err

--- a/usb_test.go
+++ b/usb_test.go
@@ -16,6 +16,7 @@
 package gousb
 
 import (
+	"syscall"
 	"testing"
 )
 
@@ -101,10 +102,15 @@ func TestOpenDeviceWithFileDescriptor(t *testing.T) {
 	ctx := NewContext()
 	defer ctx.Close()
 
-	descriptor := "/dev/bus/usb/001/003"
-	device, err := ctx.OpenDeviceWithFileDescriptor(descriptor)
+	fd, err := syscall.Open("/dev/bus/usb/001/003", syscall.O_RDWR, 0)
 	if err != nil {
-		t.Errorf("OpenDeviceWithFileDescriptor: failed opening device %s", descriptor)
+
+		t.Fatal(err)
+	}
+
+	device, err := ctx.OpenDeviceWithFileDescriptor(uintptr(fd))
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	device.Close()

--- a/usb_test.go
+++ b/usb_test.go
@@ -15,7 +15,9 @@
 
 package gousb
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestOPenDevices(t *testing.T) {
 	t.Parallel()
@@ -93,4 +95,18 @@ func TestOpenDeviceWithVIDPID(t *testing.T) {
 			dev.Close()
 		}
 	}
+}
+
+func TestOpenDeviceWithFileDescriptor(t *testing.T) {
+	ctx := NewContext()
+	defer ctx.Close()
+
+	descriptor := "/dev/bus/usb/001/002"
+	device, err := ctx.OpenDeviceWithFileDescriptor(descriptor)
+	if err != nil {
+		t.Errorf("OpenDeviceWithFileDescriptor: failed opening device %s", descriptor)
+	}
+
+	device.Close()
+
 }

--- a/usb_test.go
+++ b/usb_test.go
@@ -101,7 +101,7 @@ func TestOpenDeviceWithFileDescriptor(t *testing.T) {
 	ctx := NewContext()
 	defer ctx.Close()
 
-	descriptor := "/dev/bus/usb/001/002"
+	descriptor := "/dev/bus/usb/001/003"
 	device, err := ctx.OpenDeviceWithFileDescriptor(descriptor)
 	if err != nil {
 		t.Errorf("OpenDeviceWithFileDescriptor: failed opening device %s", descriptor)


### PR DESCRIPTION
Since Android has limitations for enumerating devices ([see](https://github.com/libusb/libusb/wiki/Android)), it would be useful to have other ways of opening devices.

This PR adds a new function to open a device provided its file descriptor, along with it also allows the user to set the [`LIBUSB_OPTION_NO_DEVICE_DISCOVERY `](https://libusb.sourceforge.io/api-1.0/group__libusb__lib.html#gga07d4ec54cf575d672ba94c72b3c0de7ca5534030a8299c85555aebfae39161ef7), again, to try to overcome the Android limitations.

This PR is missing some work on the tests, plus I'm not sure if the way I modified the API follows your standards, please let me know.