### PR TITLE
Add unknown interface descriptors to Extra

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -51,6 +51,8 @@ type InterfaceSetting struct {
 	// Endpoints enumerates the endpoints available on this interface with
 	// this alternate setting.
 	Endpoints map[EndpointAddress]EndpointDesc
+	// Unknown interface descriptors
+	Extra []byte
 
 	iInterface int // index of a string descriptor describing this interface.
 }

--- a/libusb.go
+++ b/libusb.go
@@ -301,12 +301,14 @@ func (libusbImpl) getDeviceDesc(d *libusbDevice) (*DeviceDesc, error) {
 			}
 			descs := make([]InterfaceSetting, 0, len(alts))
 			for _, alt := range alts {
+
 				i := InterfaceSetting{
 					Number:     int(alt.bInterfaceNumber),
 					Alternate:  int(alt.bAlternateSetting),
 					Class:      Class(alt.bInterfaceClass),
 					SubClass:   Class(alt.bInterfaceSubClass),
 					Protocol:   Protocol(alt.bInterfaceProtocol),
+					Extra:      C.GoBytes(unsafe.Pointer(alt.extra), alt.extra_length),
 					iInterface: int(alt.iInterface),
 				}
 


### PR DESCRIPTION
Include the [extra interface descriptors](https://libusb.sourceforge.io/api-1.0/structlibusb__interface__descriptor.html#aa1169e8c0b22a9928bbd51169609f31d) that libusb includes.