### PR TITLE
fix: amend alternative interface settings lookup

### DIFF
--- a/config.go
+++ b/config.go
@@ -137,7 +137,7 @@ func (c *Config) Interface(num, alt int) (*Interface, error) {
 	}
 
 	// Select an alternate setting if needed (device has multiple alternate settings).
-	if len(c.Desc.Interfaces[num].AltSettings) > 1 {
+	if len(c.Desc.Interfaces[num-1].AltSettings) > 1 {
 		if err := c.dev.ctx.libusb.setAlt(c.dev.handle, uint8(num), uint8(alt)); err != nil {
 			c.dev.ctx.libusb.release(c.dev.handle, uint8(num))
 			return nil, fmt.Errorf("failed to set alternate config %d on interface %d of %s: %v", alt, num, c, err)

--- a/config.go
+++ b/config.go
@@ -137,10 +137,12 @@ func (c *Config) Interface(num, alt int) (*Interface, error) {
 	}
 
 	// Select an alternate setting if needed (device has multiple alternate settings).
-	if len(c.Desc.Interfaces[num-1].AltSettings) > 1 {
-		if err := c.dev.ctx.libusb.setAlt(c.dev.handle, uint8(num), uint8(alt)); err != nil {
-			c.dev.ctx.libusb.release(c.dev.handle, uint8(num))
-			return nil, fmt.Errorf("failed to set alternate config %d on interface %d of %s: %v", alt, num, c, err)
+	for i := range c.Desc.Interfaces {
+		if c.Desc.Interfaces[i].Number == num && len(c.Desc.Interfaces[i].AltSettings) > 1 {
+			if err := c.dev.ctx.libusb.setAlt(c.dev.handle, uint8(num), uint8(alt)); err != nil {
+				c.dev.ctx.libusb.release(c.dev.handle, uint8(num))
+				return nil, fmt.Errorf("failed to set alternate config %d on interface %d of %s: %v", alt, num, c, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
fix: amend alternative interface settings lookup

---

Validations in the following screenshot show the before the changes applied and after, once with the index out of range error and second with the error resolved, and the firmware version and status being read from the device:

![Screenshot 2024-07-10 at 19 54 19](https://github.com/google/gousb/assets/84131395/3ca15461-360b-4bd4-95d4-ca6338050118)

---

Closes #123

Closes #128 