### PR TITLE
Android support via fileDescriptor 

### DIFF
--- a/fakelibusb_devices.go
+++ b/fakelibusb_devices.go
@@ -16,9 +16,10 @@ package gousb
 
 // fake devices connected through the fakeLibusb stack.
 type fakeDevice struct {
-	devDesc *DeviceDesc
-	strDesc map[int]string
-	alt     uint8
+	devDesc   *DeviceDesc
+	strDesc   map[int]string
+	alt       uint8
+	sysDevPtr uintptr
 }
 
 var fakeDevices = []fakeDevice{
@@ -64,6 +65,7 @@ var fakeDevices = []fakeDevice{
 				}},
 			}},
 		},
+		sysDevPtr: 78,
 	},
 	// Bus 001 Device 002: ID 8888:0002
 	// One config, two interfaces. interface #0 with no endpoints,
@@ -186,6 +188,7 @@ var fakeDevices = []fakeDevice{
 			8: "Slower streaming",
 			9: "Interface for https://github.com/google/gousb/issues/65",
 		},
+		sysDevPtr: 94,
 	},
 	// Bus 001 Device 003: ID 9999:0002
 	// One config, one interface, one setup,

--- a/fakelibusb_test.go
+++ b/fakelibusb_test.go
@@ -98,7 +98,9 @@ type fakeLibusb struct {
 	claims map[*libusbDevice]map[uint8]bool
 }
 
-func (f *fakeLibusb) init() (*libusbContext, error)                       { return newContextPointer(), nil }
+func (f *fakeLibusb) init(flags ...libusbOpt) (*libusbContext, error) {
+	return newContextPointer(), nil
+}
 func (f *fakeLibusb) handleEvents(c *libusbContext, done <-chan struct{}) { <-done }
 func (f *fakeLibusb) getDevices(*libusbContext) ([]*libusbDevice, error) {
 	ret := make([]*libusbDevice, 0, len(fakeDevices))

--- a/fakelibusb_test.go
+++ b/fakelibusb_test.go
@@ -111,13 +111,14 @@ func (f *fakeLibusb) getDevices(*libusbContext) ([]*libusbDevice, error) {
 }
 
 func (f *fakeLibusb) wrapSysDevice(ctx *libusbContext, systemDeviceHandle uintptr) (*libusbDevHandle, error) {
-	if _, ok := f.fakeSysDevices[systemDeviceHandle]; !ok {
-		return nil, fmt.Errorf("The passed file descriptor %d does not point to a valid device", systemDeviceHandle)
+	dev, ok := f.fakeSysDevices[systemDeviceHandle]
+	if !ok {
+		return nil, fmt.Errorf("the passed file descriptor %d does not point to a valid device", systemDeviceHandle)
 	}
 	h := newDevHandlePointer()
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.handles[h] = f.fakeSysDevices[systemDeviceHandle]
+	f.handles[h] = dev
 	return h, nil
 }
 

--- a/fakelibusb_test.go
+++ b/fakelibusb_test.go
@@ -110,7 +110,7 @@ func (f *fakeLibusb) getDevices(*libusbContext) ([]*libusbDevice, error) {
 	return ret, nil
 }
 
-func (f *fakeLibusb) wrapSysDevice(ctx *libusbContext, systemDeviceHandle int) (*libusbDevHandle, error) {
+func (f *fakeLibusb) wrapSysDevice(ctx *libusbContext, systemDeviceHandle uintptr) (*libusbDevHandle, error) {
 	//TODO should we do something for this
 	return nil, nil
 }

--- a/fakelibusb_test.go
+++ b/fakelibusb_test.go
@@ -108,6 +108,16 @@ func (f *fakeLibusb) getDevices(*libusbContext) ([]*libusbDevice, error) {
 	return ret, nil
 }
 
+func (f *fakeLibusb) wrapSysDevice(ctx *libusbContext, systemDeviceHandle int) (*libusbDevHandle, error) {
+	//TODO should we do something for this
+	return nil, nil
+}
+
+func (f *fakeLibusb) getDevice(d *libusbDevHandle) (*libusbDevice, error) {
+	//TODO should we do something for this
+	return nil, nil
+}
+
 func (f *fakeLibusb) exit(*libusbContext) error {
 	close(f.submitted)
 	if got := len(f.ts); got > 0 {

--- a/libusb.go
+++ b/libusb.go
@@ -174,9 +174,9 @@ type libusbIntf interface {
 
 // libusbImpl is an implementation of libusbIntf using real CGo-wrapped libusb.
 type libusbImpl struct {
-	logLevel         int
-	disableDiscovery bool
-	useUsbDK         bool
+	logLevel     int
+	discovery    DeviceDiscovery
+	useUSBDevKit bool
 }
 
 func (impl libusbImpl) init() (*libusbContext, error) {
@@ -191,11 +191,11 @@ func (impl libusbImpl) init() (*libusbContext, error) {
 		copy(libusb_options[n_options].value[:], b)
 		n_options += 1
 	}
-	if impl.useUsbDK {
+	if impl.useUSBDevKit {
 		libusb_options[n_options].option = C.LIBUSB_OPTION_USE_USBDK
 		n_options += 1
 	}
-	if impl.disableDiscovery {
+	if impl.discovery == DisableDeviceDiscovery {
 		libusb_options[n_options].option = C.LIBUSB_OPTION_NO_DEVICE_DISCOVERY
 		n_options += 1
 	}

--- a/libusb.go
+++ b/libusb.go
@@ -186,12 +186,12 @@ func (libusbImpl) init(flags ...libusbOpt) (*libusbContext, error) {
 		return nil, err
 	}
 
-	// for _, flag := range flags {
-	// 	switch flag {
-	// 	case LIBUSB_OPTION_NO_DEVICE_DISCOVERY:
-	// 		C.gousb_no_svc_discovery(ctx)
-	// 	}
-	// }
+	for _, flag := range flags {
+		switch flag {
+		case LIBUSB_OPTION_NO_DEVICE_DISCOVERY:
+			C.gousb_disable_device_discovery(ctx)
+		}
+	}
 
 	return (*libusbContext)(ctx), nil
 }

--- a/libusb.go
+++ b/libusb.go
@@ -40,7 +40,6 @@ type libusbDevice C.libusb_device
 type libusbDevHandle C.libusb_device_handle
 type libusbTransfer C.struct_libusb_transfer
 type libusbEndpoint C.struct_libusb_endpoint_descriptor
-type libusbLogLevel C.enum_libusb_log_level
 
 func (ep libusbEndpoint) endpointDesc(dev *DeviceDesc) EndpointDesc {
 	ei := EndpointDesc{

--- a/libusb.go
+++ b/libusb.go
@@ -178,14 +178,14 @@ type libusbImpl struct {
 func (impl libusbImpl) init() (*libusbContext, error) {
 	var ctx *C.libusb_context
 
-	var libusb_options [4]C.struct_libusb_init_option // fixed to 4 - there are maximum 4 options
-	n_options := 0
+	var libusbOpts [4]C.struct_libusb_init_option // fixed to 4 - there are maximum 4 options
+	nOpts := 0
 	if impl.discovery == DisableDeviceDiscovery {
-		libusb_options[n_options].option = C.LIBUSB_OPTION_NO_DEVICE_DISCOVERY
-		n_options += 1
+		libusbOpts[nOpts].option = C.LIBUSB_OPTION_NO_DEVICE_DISCOVERY
+		nOpts++
 	}
 
-	if err := fromErrNo(C.libusb_init_context(&ctx, &(libusb_options[0]), C.int(n_options))); err != nil {
+	if err := fromErrNo(C.libusb_init_context(&ctx, &(libusbOpts[0]), C.int(nOpts))); err != nil {
 		return nil, err
 	}
 

--- a/libusb.go
+++ b/libusb.go
@@ -143,6 +143,7 @@ type libusbIntf interface {
 	dereference(*libusbDevice)
 	getDeviceDesc(*libusbDevice) (*DeviceDesc, error)
 	open(*libusbDevice) (*libusbDevHandle, error)
+	wrapSysDevice(*libusbContext, int) (*libusbDevHandle, error)
 
 	close(*libusbDevHandle)
 	reset(*libusbDevHandle) error
@@ -152,6 +153,7 @@ type libusbIntf interface {
 	getStringDesc(*libusbDevHandle, int) (string, error)
 	setAutoDetach(*libusbDevHandle, int) error
 	detachKernelDriver(*libusbDevHandle, uint8) error
+	getDevice(*libusbDevHandle) (*libusbDevice, error)
 
 	// interface
 	claim(*libusbDevHandle, uint8) error
@@ -215,6 +217,24 @@ func (libusbImpl) getDevices(ctx *libusbContext) ([]*libusbDevice, error) {
 	// devices must be dereferenced by the caller to prevent memory leaks.
 	C.libusb_free_device_list(list, 0)
 	return ret, nil
+}
+
+func (libusbImpl) wrapSysDevice(ctx *libusbContext, systemDeviceHandle int) (*libusbDevHandle, error) {
+	var handle *C.libusb_device_handle
+	if ret := C.libusb_wrap_sys_device((*C.libusb_context)(ctx), C.intptr_t(systemDeviceHandle), &handle); ret < 0 {
+		return nil, fromErrNo(C.int(ret))
+	}
+
+	return (*libusbDevHandle)(handle), nil
+}
+
+func (libusbImpl) getDevice(d *libusbDevHandle) (*libusbDevice, error) {
+	device := C.libusb_get_device((*C.libusb_device_handle)(d))
+	if device == nil {
+		return nil, fmt.Errorf("libusb_get_device failed")
+	}
+
+	return (*libusbDevice)(device), nil
 }
 
 func (libusbImpl) exit(c *libusbContext) error {

--- a/libusb.go
+++ b/libusb.go
@@ -15,7 +15,6 @@
 package gousb
 
 import (
-	"encoding/binary"
 	"fmt"
 	"log"
 	"reflect"
@@ -174,9 +173,7 @@ type libusbIntf interface {
 
 // libusbImpl is an implementation of libusbIntf using real CGo-wrapped libusb.
 type libusbImpl struct {
-	logLevel     int
-	discovery    DeviceDiscovery
-	useUSBDevKit bool
+	discovery DeviceDiscovery
 }
 
 func (impl libusbImpl) init() (*libusbContext, error) {
@@ -184,17 +181,6 @@ func (impl libusbImpl) init() (*libusbContext, error) {
 
 	var libusb_options [4]C.struct_libusb_init_option // fixed to 4 - there are maximum 4 options
 	n_options := 0
-	if impl.logLevel != C.LIBUSB_LOG_LEVEL_NONE {
-		libusb_options[n_options].option = C.LIBUSB_OPTION_LOG_LEVEL
-		b := make([]byte, 8)
-		binary.LittleEndian.PutUint64(b, uint64(impl.logLevel))
-		copy(libusb_options[n_options].value[:], b)
-		n_options += 1
-	}
-	if impl.useUSBDevKit {
-		libusb_options[n_options].option = C.LIBUSB_OPTION_USE_USBDK
-		n_options += 1
-	}
 	if impl.discovery == DisableDeviceDiscovery {
 		libusb_options[n_options].option = C.LIBUSB_OPTION_NO_DEVICE_DISCOVERY
 		n_options += 1

--- a/libusb.go
+++ b/libusb.go
@@ -150,7 +150,7 @@ type libusbIntf interface {
 	dereference(*libusbDevice)
 	getDeviceDesc(*libusbDevice) (*DeviceDesc, error)
 	open(*libusbDevice) (*libusbDevHandle, error)
-	wrapSysDevice(*libusbContext, int) (*libusbDevHandle, error)
+	wrapSysDevice(*libusbContext, uintptr) (*libusbDevHandle, error)
 
 	close(*libusbDevHandle)
 	reset(*libusbDevHandle) error
@@ -234,9 +234,9 @@ func (libusbImpl) getDevices(ctx *libusbContext) ([]*libusbDevice, error) {
 	return ret, nil
 }
 
-func (libusbImpl) wrapSysDevice(ctx *libusbContext, systemDeviceHandle int) (*libusbDevHandle, error) {
+func (libusbImpl) wrapSysDevice(ctx *libusbContext, fd uintptr) (*libusbDevHandle, error) {
 	var handle *C.libusb_device_handle
-	if ret := C.libusb_wrap_sys_device((*C.libusb_context)(ctx), C.intptr_t(systemDeviceHandle), &handle); ret < 0 {
+	if ret := C.libusb_wrap_sys_device((*C.libusb_context)(ctx), C.intptr_t(fd), &handle); ret < 0 {
 		return nil, fromErrNo(C.int(ret))
 	}
 

--- a/usb.c
+++ b/usb.c
@@ -24,4 +24,3 @@ void gousb_set_debug(libusb_context *ctx, int lvl) {
     libusb_set_debug(ctx, lvl);
 #endif
 }
-

--- a/usb.c
+++ b/usb.c
@@ -24,3 +24,7 @@ void gousb_set_debug(libusb_context *ctx, int lvl) {
     libusb_set_debug(ctx, lvl);
 #endif
 }
+
+int gousb_disable_device_discovery(libusb_context *ctx) {
+  return libusb_set_option(ctx, 2);
+}

--- a/usb.c
+++ b/usb.c
@@ -25,6 +25,3 @@ void gousb_set_debug(libusb_context *ctx, int lvl) {
 #endif
 }
 
-int gousb_disable_device_discovery(libusb_context *ctx) {
-  return libusb_set_option(ctx, 2);
-}

--- a/usb.go
+++ b/usb.go
@@ -169,12 +169,17 @@ func NewContext() *Context {
 }
 
 // DeviceDiscovery controls USB device discovery.
-// When set to EnableDeviceDiscovery (default), the connected USB devices will be discovered and enumerated, allowing the use os OpenDevices and OpenWithVIDPID.
-// When set to DisableDeviceDiscovery, OpenDevices will not return any devices. OpenDeviceWithFileDescriptor can be used on some systems to open a device that was otherwise discovered through the operating system.
 type DeviceDiscovery int
 
 const (
+	// EnableDeviceDiscovery means the connected USB devices will be enumerated
+	// on Context initialization. This enables the use of OpenDevices and
+	// OpenWithVIDPID. This is the default.
 	EnableDeviceDiscovery = iota
+	// DisableDeviceDiscovery means the USB devices are not enumerated and
+	// OpenDevices will not return any devices.
+	// Without device discovery, OpenDeviceWithFileDescriptor can be used
+	// to open devices.
 	DisableDeviceDiscovery
 )
 
@@ -232,12 +237,16 @@ func (c *Context) OpenDevices(opener func(desc *DeviceDesc) bool) ([]*Device, er
 	return ret, reterr
 }
 
-// OpenDeviceWithFileDescriptor takes a (Unix) file descriptor of an opened USB device
-// and wraps the library around it.
-// This is particularly useful when working on Android, where the USB device can be opened
-// by the SDK (Java), giving access to the device through the file descriptor (https://developer.android.com/reference/android/hardware/usb/UsbDeviceConnection#getFileDescriptor()).
+// OpenDeviceWithFileDescriptor takes a (Unix) file descriptor of an opened USB
+// device and wraps the library around it.
+// This is particularly useful when working on Android, where the USB device can be
+// opened by the SDK (Java), giving access to the device through the file descriptor
+// (https://developer.android.com/reference/android/hardware/usb/UsbDeviceConnection#getFileDescriptor()).
 //
-// Do note that for this to work the automatic device discovery must be disabled at the time when the new Context is created, through the use of ContextOptions.DeviceDiscovery.
+// Do note that for this to work the automatic device discovery must be disabled
+// at the time when the new Context is created, through the use of
+// ContextOptions.DeviceDiscovery.
+//
 // Example:
 //
 //	ctx := ContextOptions{DeviceDiscovery: DisableDeviceDiscovery}.New()

--- a/usb.go
+++ b/usb.go
@@ -259,7 +259,6 @@ func (c *Context) OpenDeviceWithFileDescriptor(fd uintptr) (*Device, error) {
 		return nil, err
 	}
 	dev := c.libusb.getDevice(handle)
-
 	desc, err := c.libusb.getDeviceDesc(dev)
 	if err != nil {
 		return nil, fmt.Errorf("device was opened, but getting device descriptor failed: %v", err)

--- a/usb.go
+++ b/usb.go
@@ -140,17 +140,6 @@ type Context struct {
 	devices map[*Device]bool
 }
 
-// LogLevel values match the levels of libusb
-type LogLevel int
-
-const (
-	LogLevelNone    = 0
-	LogLevelError   = 1
-	LogLevelWarning = 2
-	LogLevelInfo    = 3
-	LogLevelDebug   = 4
-)
-
 // Debug changes the debug level. Level 0 means no debug, higher levels
 // will print out more debugging information.
 // TODO(sebek): in the next major release, replace int levels with
@@ -187,16 +176,12 @@ const (
 )
 
 type ContextOptions struct {
-	LogLevel        LogLevel
 	DeviceDiscovery DeviceDiscovery
-	UseUSBDevKit    bool
 }
 
 func (o ContextOptions) New() *Context {
 	return newContextWithImpl(libusbImpl{
-		discovery:    o.DeviceDiscovery,
-		logLevel:     int(o.LogLevel),
-		useUSBDevKit: o.UseUSBDevKit,
+		discovery: o.DeviceDiscovery,
 	})
 }
 

--- a/usb.go
+++ b/usb.go
@@ -179,17 +179,24 @@ func NewContext() *Context {
 	return newContextWithImpl(libusbImpl{})
 }
 
+type DeviceDiscovery int
+
+const (
+	EnableDeviceDiscovery = iota
+	DisableDeviceDiscovery
+)
+
 type ContextOptions struct {
-	LogLevel               LogLevel
-	DisableDeviceDiscovery bool
-	UseUsbDK               bool
+	LogLevel        LogLevel
+	DeviceDiscovery DeviceDiscovery
+	UseUSBDevKit    bool
 }
 
-func (o *ContextOptions) NewContext() *Context {
+func (o ContextOptions) New() *Context {
 	return newContextWithImpl(libusbImpl{
-		disableDiscovery: o.DisableDeviceDiscovery,
-		logLevel:         int(o.LogLevel),
-		useUsbDK:         o.UseUsbDK,
+		discovery:    o.DeviceDiscovery,
+		logLevel:     int(o.LogLevel),
+		useUSBDevKit: o.UseUSBDevKit,
 	})
 }
 

--- a/usb.go
+++ b/usb.go
@@ -128,7 +128,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"syscall"
 )
 
 // Context manages all resources related to USB device handling.
@@ -211,12 +210,7 @@ func (c *Context) OpenDevices(opener func(desc *DeviceDesc) bool) ([]*Device, er
 	return ret, reterr
 }
 
-func (c *Context) OpenDeviceWithFileDescriptor(fileDescriptor string) (*Device, error) {
-	fd, err := syscall.Open(fileDescriptor, syscall.O_RDWR, 0)
-	if err != nil {
-		return nil, err
-	}
-
+func (c *Context) OpenDeviceWithFileDescriptor(fd uintptr) (*Device, error) {
 	handle, err := c.libusb.wrapSysDevice(c.ctx, fd)
 	if err != nil {
 		return nil, err

--- a/usb_test.go
+++ b/usb_test.go
@@ -109,10 +109,10 @@ func TestOpenDeviceWithFileDescriptor(t *testing.T) {
 	} {
 		dev, err := ctx.OpenDeviceWithFileDescriptor(d.sysDevPtr)
 		if err != nil {
-			t.Errorf("OpenDeviceWithFileDescriptor(%d): err != nil for a valid device: %v", d.sysDevPtr, err)
+			t.Fatalf("OpenDeviceWithFileDescriptor(%d): err != nil for a valid device: %v", d.sysDevPtr, err)
 		}
 		if dev == nil {
-			t.Errorf("OpenDeviceWithFileDescriptor(%d): device == nil for a valid device", d.sysDevPtr)
+			t.Fatalf("OpenDeviceWithFileDescriptor(%d): device == nil for a valid device", d.sysDevPtr)
 		}
 		if dev != nil && (dev.Desc.Vendor != ID(d.vid) || dev.Desc.Product != ID(d.pid)) {
 			t.Errorf("OpenDeviceWithFileDescriptor(%d): device's VID/PID %s/%s don't match expected: %s/%s", d.sysDevPtr, dev.Desc.Vendor, dev.Desc.Product, ID(d.vid), ID(d.pid))

--- a/usb_test.go
+++ b/usb_test.go
@@ -109,13 +109,13 @@ func TestOpenDeviceWithFileDescriptor(t *testing.T) {
 	} {
 		dev, err := ctx.OpenDeviceWithFileDescriptor(d.sysDevPtr)
 		if err != nil {
-			t.Fatalf("OpenDeviceWithFileDescriptor(%d): err != nil for a valid device: %v", d.sysDevPtr, err)
+			t.Errorf("OpenDeviceWithFileDescriptor(%d): err != nil for a valid device: %v", d.sysDevPtr, err)
 		}
 		if dev == nil {
-			t.Fatalf("OpenDeviceWithFileDescriptor(%d): device == nil for a valid device", d.sysDevPtr)
+			t.Errorf("OpenDeviceWithFileDescriptor(%d): device == nil for a valid device", d.sysDevPtr)
 		}
-		if dev.Desc.Vendor != ID(d.vid) || dev.Desc.Product != ID(d.pid) {
-			t.Fatalf("OpenDeviceWithFileDescriptor(%d): device's VID/PID %s/%s don't match expected: %s/%s", d.sysDevPtr, dev.Desc.Vendor, dev.Desc.Product, ID(d.vid), ID(d.pid))
+		if dev != nil && (dev.Desc.Vendor != ID(d.vid) || dev.Desc.Product != ID(d.pid)) {
+			t.Errorf("OpenDeviceWithFileDescriptor(%d): device's VID/PID %s/%s don't match expected: %s/%s", d.sysDevPtr, dev.Desc.Vendor, dev.Desc.Product, ID(d.vid), ID(d.pid))
 		}
 	}
 

--- a/usb_test.go
+++ b/usb_test.go
@@ -16,6 +16,7 @@
 package gousb
 
 import (
+	"syscall"
 	"testing"
 )
 
@@ -101,10 +102,15 @@ func TestOpenDeviceWithFileDescriptor(t *testing.T) {
 	ctx := NewContext()
 	defer ctx.Close()
 
-	descriptor := "/dev/bus/usb/001/003"
-	device, err := ctx.OpenDeviceWithFileDescriptor(descriptor)
+	fd, err := syscall.Open("/dev/bus/usb/001/003", syscall.O_RDWR, 0)
 	if err != nil {
-		t.Errorf("OpenDeviceWithFileDescriptor: failed opening device %s", descriptor)
+
+		t.Fatal(err)
+	}
+
+	device, err := ctx.OpenDeviceWithFileDescriptor(uintptr(fd))
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	device.Close()

--- a/usb_test.go
+++ b/usb_test.go
@@ -15,7 +15,9 @@
 
 package gousb
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestOPenDevices(t *testing.T) {
 	t.Parallel()
@@ -93,4 +95,18 @@ func TestOpenDeviceWithVIDPID(t *testing.T) {
 			dev.Close()
 		}
 	}
+}
+
+func TestOpenDeviceWithFileDescriptor(t *testing.T) {
+	ctx := NewContext()
+	defer ctx.Close()
+
+	descriptor := "/dev/bus/usb/001/002"
+	device, err := ctx.OpenDeviceWithFileDescriptor(descriptor)
+	if err != nil {
+		t.Errorf("OpenDeviceWithFileDescriptor: failed opening device %s", descriptor)
+	}
+
+	device.Close()
+
 }

--- a/usb_test.go
+++ b/usb_test.go
@@ -108,11 +108,13 @@ func TestOpenDeviceWithFileDescriptor(t *testing.T) {
 		{0x8888, 0x0002, 94},
 	} {
 		dev, err := ctx.OpenDeviceWithFileDescriptor(d.sysDevPtr)
-		if dev == nil {
-			t.Errorf("OpenDeviceWithFileDescriptor(%d): device == nil for a valid device", d.sysDevPtr)
-		}
 		if err != nil {
-			t.Errorf("OpenDeviceWithFileDescriptor(%d): err != nil for a valid device: %v", d.sysDevPtr, err)
+			t.Fatalf("OpenDeviceWithFileDescriptor(%d): err != nil for a valid device: %v", d.sysDevPtr, err)
+		}
+		if dev == nil {
+			t.Fatalf("OpenDeviceWithFileDescriptor(%d): device == nil for a valid device", d.sysDevPtr)
+		} else if dev.Desc.Vendor != ID(d.vid) || dev.Desc.Product != ID(d.pid) {
+			t.Fatalf("OpenDeviceWithFileDescriptor(%d): device's VID/PID %s/%s don't match expected: %s/%s", d.sysDevPtr, dev.Desc.Vendor, dev.Desc.Product, ID(d.vid), ID(d.pid))
 		}
 	}
 
@@ -126,12 +128,9 @@ func TestOpenDeviceWithFileDescriptorOnMissingDevice(t *testing.T) {
 		7, // set, but does not exist in the fakeDevices array
 		0, // unset
 	} {
-		dev, err := ctx.OpenDeviceWithFileDescriptor(sysDevPtr)
+		_, err := ctx.OpenDeviceWithFileDescriptor(sysDevPtr)
 		if err == nil {
 			t.Errorf("OpenDeviceWithFileDescriptor(%d): got nil error for invalid device", sysDevPtr)
-		}
-		if dev != nil {
-			t.Errorf("OpenDeviceWithFileDescriptor(%d): got non-nil device for invalid device", sysDevPtr)
 		}
 	}
 

--- a/usb_test.go
+++ b/usb_test.go
@@ -101,7 +101,7 @@ func TestOpenDeviceWithFileDescriptor(t *testing.T) {
 	ctx := NewContext()
 	defer ctx.Close()
 
-	descriptor := "/dev/bus/usb/001/002"
+	descriptor := "/dev/bus/usb/001/003"
 	device, err := ctx.OpenDeviceWithFileDescriptor(descriptor)
 	if err != nil {
 		t.Errorf("OpenDeviceWithFileDescriptor: failed opening device %s", descriptor)

--- a/usb_test.go
+++ b/usb_test.go
@@ -113,7 +113,8 @@ func TestOpenDeviceWithFileDescriptor(t *testing.T) {
 		}
 		if dev == nil {
 			t.Fatalf("OpenDeviceWithFileDescriptor(%d): device == nil for a valid device", d.sysDevPtr)
-		} else if dev.Desc.Vendor != ID(d.vid) || dev.Desc.Product != ID(d.pid) {
+		}
+		if dev.Desc.Vendor != ID(d.vid) || dev.Desc.Product != ID(d.pid) {
 			t.Fatalf("OpenDeviceWithFileDescriptor(%d): device's VID/PID %s/%s don't match expected: %s/%s", d.sysDevPtr, dev.Desc.Vendor, dev.Desc.Product, ID(d.vid), ID(d.pid))
 		}
 	}
@@ -128,8 +129,7 @@ func TestOpenDeviceWithFileDescriptorOnMissingDevice(t *testing.T) {
 		7, // set, but does not exist in the fakeDevices array
 		0, // unset
 	} {
-		_, err := ctx.OpenDeviceWithFileDescriptor(sysDevPtr)
-		if err == nil {
+		if _, err := ctx.OpenDeviceWithFileDescriptor(sysDevPtr); err == nil {
 			t.Errorf("OpenDeviceWithFileDescriptor(%d): got nil error for invalid device", sysDevPtr)
 		}
 	}


### PR DESCRIPTION
See base #126 
Since libusb supports the peculiar Android USB handling (usb device must be opened from Java, _after_ acquiring permission from the user to do so) it's useful to enable gousb to do the same.

Checked using a basic Android app with a USB serial device in loopback.

Documentation is not yet done, if the code changes are OK, I'll write the docstrings as well